### PR TITLE
Add comprehensive styles for landing page

### DIFF
--- a/style.css
+++ b/style.css
@@ -73,3 +73,254 @@ footer .contact-info p {
   font-size: 0.9em;
 }
 
+/* Header tagline */
+.tagline {
+  margin-top: 10px;
+  font-family: 'Space Mono', monospace;
+  font-size: 1.2rem;
+  color: var(--indigo);
+  text-align: center;
+}
+
+/* Animated sound waves */
+.sound-waves {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 4px;
+  height: 40px;
+  margin: 20px 0;
+}
+
+.sound-wave {
+  width: 4px;
+  background: var(--magenta);
+  animation: wave 1s infinite ease-in-out;
+}
+
+.sound-wave:nth-child(2) { animation-delay: 0.1s; }
+.sound-wave:nth-child(3) { animation-delay: 0.2s; }
+.sound-wave:nth-child(4) { animation-delay: 0.3s; }
+.sound-wave:nth-child(5) { animation-delay: 0.4s; }
+.sound-wave:nth-child(6) { animation-delay: 0.5s; }
+.sound-wave:nth-child(7) { animation-delay: 0.6s; }
+
+@keyframes wave {
+  0%, 100% { height: 5px; }
+  50% { height: 40px; }
+}
+
+/* Retro card */
+.retro-card {
+  background: #fff;
+  border: 2px solid var(--dark-gray);
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  margin: 20px auto;
+  padding: 20px;
+  max-width: 800px;
+}
+
+/* FAQ section inherits retro-card styles */
+.retro-card.faq {
+  background: #f9f9f9;
+}
+
+.faq .question {
+  font-weight: bold;
+  margin-top: 15px;
+}
+
+/* Audio demo */
+.audio-demo {
+  margin-top: 20px;
+}
+
+.audio-player-container {
+  margin-top: 15px;
+}
+
+.track-buttons {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.track-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--indigo);
+  color: var(--light-gray);
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.track-btn.active,
+.track-btn:hover {
+  background: var(--magenta);
+}
+
+.audio-player {
+  background: var(--black);
+  color: var(--light-gray);
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.player-info {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.9rem;
+}
+
+.player-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.play-pause-btn {
+  background: var(--cyan);
+  border: none;
+  border-radius: 4px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.progress-container {
+  flex-grow: 1;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--dark-gray);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  width: 0;
+  height: 100%;
+  background: var(--cyan);
+}
+
+.volume-container {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.volume-slider {
+  width: 80px;
+}
+
+/* Video placeholder */
+.video-placeholder {
+  max-width: 560px;
+  margin: 40px auto;
+}
+
+.video-wrapper {
+  position: relative;
+  padding-top: 56.25%;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.video-thumbnail {
+  position: relative;
+  cursor: pointer;
+}
+
+.play-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.3s;
+  border-radius: 15px;
+}
+
+.video-thumbnail:hover .play-overlay {
+  opacity: 1;
+}
+
+.play-button {
+  font-size: 3rem;
+  color: var(--light-gray);
+}
+
+/* Call to action */
+.cta-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin: 40px 0;
+}
+
+.retro-button {
+  background: var(--magenta);
+  color: var(--light-gray);
+  text-decoration: none;
+  padding: 15px 25px;
+  border-radius: 4px;
+  box-shadow: 0 4px 0 var(--indigo);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.retro-button:active {
+  transform: translateY(2px);
+  box-shadow: 0 2px 0 var(--indigo);
+}
+
+/* Animated background */
+.animated-bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  overflow: hidden;
+  background: linear-gradient(45deg, var(--cyan), var(--magenta));
+}
+
+.floating-shape {
+  position: absolute;
+  width: 80px;
+  height: 80px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 50%;
+  animation: float 6s infinite ease-in-out;
+}
+
+.floating-shape:nth-child(2) { left: 20%; animation-delay: 1s; }
+.floating-shape:nth-child(3) { left: 60%; animation-delay: 2s; }
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-40px); }
+}
+


### PR DESCRIPTION
## Summary
- style tagline and animated sound waves
- add retro card, FAQ, and audio player styles
- add video placeholder and call-to-action button designs

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a988e27f58832dbc2d07e98e84a8f5