### PR TITLE
Use Orbitron and Space Mono fonts

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Space+Mono:wght@400;700&display=swap');
+
 :root {
   --black: #000000;
   --magenta: #C100E0;
@@ -14,10 +16,14 @@
 }
 
 body {
-  font-family: sans-serif;
+  font-family: 'Space Mono', monospace;
   background-color: var(--light-gray);
   color: var(--black);
   padding-top: 60px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Orbitron', sans-serif;
 }
 
 /* Navigation */


### PR DESCRIPTION
## Summary
- Import Google Fonts for Orbitron and Space Mono
- Apply Space Mono to body text and Orbitron to headings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a988ee300c832db060c2b369d3f17e