### PR TITLE
feat: add floating contact icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tony's Media and Automation</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -68,8 +69,12 @@
   </div>
 
   <div class="cta-buttons">
-    <a href="mailto:contentmage@tonysautomedia.com?subject=Service%20Inquiry&body=Hi%20Tony%2C%20I'm%20interested%20in%20your%20audio%20services.%20Please%20let%20me%20know%20more." target="_blank" class="retro-button">Write me an Email</a>
-    <a href="https://wa.me/972534384116" target="_blank" class="retro-button">Message Me on WhatsApp</a>
+    <a href="mailto:contentmage@tonysautomedia.com?subject=Service%20Inquiry&body=Hi%20Tony%2C%20I'm%20interested%20in%20your%20audio%20services.%20Please%20let%20me%20know%20more." target="_blank" class="retro-button" aria-label="Email">
+      <i class="fa-solid fa-envelope"></i>
+    </a>
+    <a href="https://wa.me/972534384116" target="_blank" class="retro-button" aria-label="WhatsApp">
+      <i class="fa-brands fa-whatsapp"></i>
+    </a>
   </div>
 
   <footer>

--- a/style.css
+++ b/style.css
@@ -32,10 +32,6 @@ body {
   background-color: var(--black);
   color: var(--light-gray);
 }
-.cta-buttons{
-  color: var(--light-gray);
-}
-
 .retro-card{
   background-color: var(--black);
   color: var(--light-gray);
@@ -47,6 +43,16 @@ body {
   gap: 20px;            /* расстояние между картами */
   justify-content: space-between;
   align-items: stretch;
+}
+
+@media (max-width: 600px) {
+  .cards-row {
+    flex-direction: column;
+  }
+
+  .cards-row .retro-card {
+    flex: none;
+  }
 }
 
 
@@ -96,22 +102,6 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nav-btn:hover {
-  background-color: var(--cyan);
-}
-
-/* Generic buttons */
-.retro-button {
-  background: transparent;
-  background-color: var(--indigo);
-  color: var(--light-gray);
-  text-decoration: none;
-  padding: 10px 20px;
-  border-radius: 4px;
-  display: inline-block;
-  transition: background-color 0.3s;
-}
-
-.retro-button:hover {
   background-color: var(--cyan);
 }
 
@@ -354,11 +344,25 @@ footer .contact-info p {
 
 /* Call to action */
 .cta-buttons {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
   display: flex;
+  flex-direction: column;
+  gap: 15px;
+  margin: 0;
+  z-index: 1000;
+}
+
+.cta-buttons .retro-button {
+  width: 60px;
+  height: 60px;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
   justify-content: center;
-  gap: 20px;
-  flex-wrap: wrap;
-  margin: 40px 0;
+  font-size: 24px;
 }
 
 .retro-button {
@@ -368,7 +372,11 @@ footer .contact-info p {
   padding: 15px 25px;
   border-radius: 4px;
   box-shadow: 0 4px 0 var(--indigo);
-  transition: transform 0.1s, box-shadow 0.1s;
+  transition: background-color 0.3s, transform 0.1s, box-shadow 0.1s;
+}
+
+.retro-button:hover {
+  background-color: var(--cyan);
 }
 
 .retro-button:active {

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tony's Audio Magic</title>
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
-</head>
+    <title>Tony's Audio Magic</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+  </head>
 <body>
   <header class="main-nav">
     <a href="index.html" class="nav-btn">Home</a>
@@ -148,8 +149,12 @@
   </div>
 
   <div class="cta-buttons">
-    <a href="#" class="retro-button">🚀 Let's Make Your Video Shine</a>
-    <a href="#" class="retro-button">📧 Send Me Your Audio Sample</a>
+    <a href="mailto:contentmage@tonysautomedia.com?subject=Service%20Inquiry&body=Hi%20Tony%2C%20I'm%20interested%20in%20your%20audio%20services.%20Please%20let%20me%20know%20more." target="_blank" class="retro-button" aria-label="Email">
+      <i class="fa-solid fa-envelope"></i>
+    </a>
+    <a href="https://wa.me/972534384116" target="_blank" class="retro-button" aria-label="WhatsApp">
+      <i class="fa-brands fa-whatsapp"></i>
+    </a>
   </div>
 
   <footer>


### PR DESCRIPTION
## Summary
- refine CTA button styles for cleaner mobile layout and bottom-right placement
- add Font Awesome and floating email/WhatsApp icons to audio page
- simplify retro button CSS with hover state

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/tonysautomedia/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a9d2e271f0832d97253a35e5b23e60