### PR TITLE
Refine contact buttons and improve audio demo page

### DIFF
--- a/style.css
+++ b/style.css
@@ -345,9 +345,9 @@ footer .contact-info p {
 /* Call to action */
 .cta-buttons {
   position: fixed;
-
-  bottom: 20px;
+  top: 50%;
   right: 20px;
+  transform: translateY(-50%);
   display: flex;
   flex-direction: column;
   gap: 15px;
@@ -356,31 +356,20 @@ footer .contact-info p {
 }
 
 .cta-buttons .retro-button {
-  width: 60px;
-  height: 60px;
+  width: 40px;
+  height: 40px;
   padding: 0;
   border-radius: 50%;
   display: flex;
-
-  bottom: 80px;
-  right: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 15px;
-  margin: 0;
-  z-index: 1000;
-}
-
-.cta-buttons .retro-button {
-  width: 60px;
-  height: 60px;
-  padding: 0;
-  border-radius: 50%;
-  display: flex;
-
   align-items: center;
   justify-content: center;
-  font-size: 24px;
+  font-size: 18px;
+  opacity: 0.6;
+  transition: opacity 0.3s;
+}
+
+.cta-buttons .retro-button:hover {
+  opacity: 1;
 }
 
 .retro-button {

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -34,9 +34,12 @@
   </header>
 
   <div class="retro-card">
-    <h2>Want Your Video to <em>Sound</em> as Good as It Looks?</h2>
-    <p>I'm Tony — I make videos <strong>feel</strong> powerful by blending voice, music, and sound effects that grab attention and keep people watching.</p>
-    <p>Whether it's a quick Reel or a full doc, I'll make sure your sound is clean, smooth, and hits just right.</p>
+    <p>Great ideas survive shaky video—bad audio kills them.</p>
+    <p>When sound is right, people relax, trust you more, and stay to the end.</p>
+    <p>Hi, I’m Tony. I make voices feel close, clear, and effortless to hear.</p>
+    <p>I’m the calm pair of ears that polishes the space around your words - so your message lands clean, warm, and true. Not louder. Better.</p>
+    <p>If your story matters, let the sound carry it.</p>
+    <p>Friendly, responsive, human.</p>
   </div>
 
   <div class="retro-card">
@@ -190,9 +193,10 @@
 
     function loadTrack(key, label) {
       audioPlayer.src = tracks[key];
+      audioPlayer.load();
       trackLabel.textContent = label;
-      audioPlayer.play();
-      playPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
+      playPauseBtn.innerHTML = '<span class="play-icon">▶️</span>';
+      trackTime.textContent = `0:00 / 0:00`;
     }
 
     trackButtons.forEach(btn => {
@@ -200,6 +204,8 @@
         trackButtons.forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
         loadTrack(btn.dataset.track, btn.querySelector('.track-label').textContent);
+        audioPlayer.play();
+        playPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
       });
     });
 
@@ -217,6 +223,10 @@
       const progress = (audioPlayer.currentTime / audioPlayer.duration) * 100;
       progressFill.style.width = `${progress || 0}%`;
       trackTime.textContent = `${formatTime(audioPlayer.currentTime)} / ${formatTime(audioPlayer.duration)}`;
+    });
+
+    audioPlayer.addEventListener('loadedmetadata', () => {
+      trackTime.textContent = `0:00 / ${formatTime(audioPlayer.duration)}`;
     });
 
     volumeSlider.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- Position email/WhatsApp buttons midway on the right, shrink them, and make them semi-transparent
- Replace the first card on the audio demo page with new introductory copy
- Prevent the audio player from auto-playing and update track loading behavior

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fb5e2a70832db60323dba1f39aca