### PR TITLE
Refine headings, cards layout, and contact buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,87 +42,71 @@
 
     <header>
       <h1>Tony's Media and Automation</h1>
-      <div class="tagline">From raw idea to <em>automised content!</em></div>
+      <div class="tagline">From raw idea to <strong>automised content!</strong></div>
     </header>
 
     <div class="retro-card">
-      <p>
-        <em><h3>Who I am:</h3></em>
-      </p>
+      <h3><strong>Who I am:</strong></h3>
       I’m a media engineer and creative automator who blends pro-level audio,
       AI-assisted visuals, and practical automation. I help creators, startups,
       and small teams ship more, polish better, and publish faster—without
       adding headcount.<br />
-      <p>
-        <em><h3>Why Me:</h3></em>
-      </p>
+      <h3><strong>Why Me:</strong></h3>
       <p>
         20+ years in media production, Nika-nominated film credit, honors degree
         in media processing, fast delivery.
       </p>
     </div>
 
-    <div class="cards-row">
+    <div class="cards_row">
       <div class="retro-card">
-        <h2>Sound & Audio <em>Polish</em></h2>
+        <h2>Sound & Audio <strong>Polish</strong></h2>
         <br />
         <p>
-          I <em>fix</em> imperfect recordings and make voices camera-ready. From
+          I <strong>fix</strong> imperfect recordings and make voices camera-ready. From
           noisy Zoom calls to podcasts and films, I deliver broadcast-grade
           sound—on time.
         </p>
         <br />
-        <p>
-          <em><h3>Services:</h3></em>
-        </p>
+        <h3><strong>Services:</strong></h3>
         <p>
           Noise reduction, dialogue cleanup, de-essing, EQ/comp, loudness to
           spec, mix/master, podcast editing, subtitles.
         </p>
         <br />
-        <p>
-          <em><h3>Deliverables:</h3></em>
-        </p>
+        <h3><strong>Deliverables:</strong></h3>
         <p>
           WAV/MP3 + stems, loudness report, optional 15-sec before/after
           preview.
         </p>
         <br />
-        <p>
-          <em><h3>Use Cases:</h3></em>
-        </p>
+        <h3><strong>Use Cases:</strong></h3>
         <p>YouTube voiceovers, podcast series, trailers, TV & doc pieces.</p>
         <br />
       </div>
 
       <div class="retro-card">
-        <h2>AI-Driven <em>Video & Music Content</em></h2>
+        <h2>AI-Driven <strong>Video & Music Content</strong></h2>
         <br />
         <p>
-          I <em>craft</em> scroll-stopping short videos with consistent AI
+          I <strong>craft</strong> scroll-stopping short videos with consistent AI
           visuals, strong hooks, and clear captions—plus original AI-generated
           music when needed.
         </p>
         <br />
-        <p>
-          <em><h3>Services:</h3></em>
-        </p>
+        <h3><strong>Services:</strong></h3>
         <p>
           Reels/Shorts (9:16), hook scripting, captioning (+ .srt),
           motion/graphics, Udio music cues, brand-safe sound, export presets.
         </p>
         <br />
-        <p>
-          <em><h3>Deliverables:</h3></em>
-        </p>
+        <h3><strong>Deliverables:</strong></h3>
         <p>
           Ready-to-publish .mp4 + .srt, thumbnail options, sound design tailored
           for your brand.
         </p>
         <br />
-        <p>
-          <em><h3>Use Cases:</h3></em>
-        </p>
+        <h3><strong>Use Cases:</strong></h3>
         <p>
           Product teasers, coaching/edu clips, artist promos, channel growth
           assets
@@ -131,33 +115,27 @@
       </div>
 
       <div class="retro-card">
-        <h2>Automation & <em>Media Systems</em></h2>
+        <h2>Automation & <strong>Media Systems</strong></h2>
         <br />
         <p>
-          I build small, reliable <em>automations</em> that eliminate repetitive
+          I build small, reliable <strong>automations</strong> that eliminate repetitive
           tasks—keeping your content moving while you stay focused on ideas.
         </p>
         <br />
+        <h3><strong>Flagship:</strong></h3>
         <p>
-          <em><h3>Flagship:</h3></em>
-        </p>
-        <p>
-          <em>Telegram → Podcast in 72h</em> capture voice notes, clean audio,
+          <strong>Telegram → Podcast in 72h</strong> capture voice notes, clean audio,
           auto-assemble episodes, generate cover art, publish via RSS or YouTube
           Podcast.
         </p>
         <br />
-        <p>
-          <em><h3>Tech Stack:</h3></em>
-        </p>
+        <h3><strong>Tech Stack:</strong></h3>
         <p>
           Make.com, Pipedream—auto-captioning, smart naming, asset routing,
           scheduled posting, backups, dashboards.
         </p>
         <br />
-        <p>
-          <em><h3>Deliverables:</h3></em>
-        </p>
+        <h3><strong>Deliverables:</strong></h3>
         <p>Working blueprints, Video walkthrough, one month support.</p>
         <br />
       </div>

--- a/style.css
+++ b/style.css
@@ -32,10 +32,20 @@ body {
   background-color: var(--black);
   color: var(--light-gray);
 }
-.cards-row {
+.cards_row {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 20px; /* расстояние между картами */
+}
+
+.cards_row .retro-card {
+  flex: 1 1 300px;
+}
+
+@media (max-width: 600px) {
+  .cards_row {
+    flex-direction: column;
+  }
 }
 
 header:not(.main-nav) h1 {
@@ -63,6 +73,8 @@ h4,
 h5,
 h6 {
   font-family: "Anton", sans-serif;
+  color: var(--magenta);
+  letter-spacing: 0.05em;
 }
 
 /* Navigation */
@@ -370,11 +382,12 @@ footer .contact-info p {
   justify-content: center;
   font-size: 18px;
   opacity: 0.6;
-  transition: opacity 0.3s;
+  transition: opacity 0.3s, transform 0.3s;
 }
 
 .cta-buttons .retro-button:hover {
   opacity: 1;
+  transform: scale(1.2);
 }
 
 .cta-buttons .retro-button.pulse {

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -42,7 +42,7 @@
     <header>
       <h1>Tony's Audio Magic</h1>
       <div class="tagline">
-        From Sound to Impact — Let Your Video <em>Be Heard</em>
+        From Sound to Impact — Let Your Video <strong>Be Heard</strong>
       </div>
       <div class="sound-waves">
         <div class="sound-wave"></div>


### PR DESCRIPTION
## Summary
- Color all headings magenta with subtle letter spacing
- Convert italicized text to bold for clearer emphasis
- Restore responsive `cards_row` layout and enlarge contact buttons on hover

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0866fe70832d92cc8644954fe108