### PR TITLE
feat: add images to service cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,84 +60,93 @@
 
     <div class="cards_row">
       <div class="retro-card">
-        <h2>Sound & Audio <strong>Polish</strong></h2>
-        <br />
-        <p>
-          I <strong>fix</strong> imperfect recordings and make voices camera-ready. From
-          noisy Zoom calls to podcasts and films, I deliver broadcast-grade
-          sound—on time.
-        </p>
-        <br />
-        <h3><strong>Services:</strong></h3>
-        <p>
-          Noise reduction, dialogue cleanup, de-essing, EQ/comp, loudness to
-          spec, mix/master, podcast editing, subtitles.
-        </p>
-        <br />
-        <h3><strong>Deliverables:</strong></h3>
-        <p>
-          WAV/MP3 + stems, loudness report, optional 15-sec before/after
-          preview.
-        </p>
-        <br />
-        <h3><strong>Use Cases:</strong></h3>
-        <p>YouTube voiceovers, podcast series, trailers, TV & doc pieces.</p>
-        <br />
+        <img src="audio_waveforms.png" alt="Audio waveforms" class="card-image" />
+        <div class="card-content">
+          <h2>Sound & Audio <strong>Polish</strong></h2>
+          <br />
+          <p>
+            I <strong>fix</strong> imperfect recordings and make voices camera-ready. From
+            noisy Zoom calls to podcasts and films, I deliver broadcast-grade
+            sound—on time.
+          </p>
+          <br />
+          <h3><strong>Services:</strong></h3>
+          <p>
+            Noise reduction, dialogue cleanup, de-essing, EQ/comp, loudness to
+            spec, mix/master, podcast editing, subtitles.
+          </p>
+          <br />
+          <h3><strong>Deliverables:</strong></h3>
+          <p>
+            WAV/MP3 + stems, loudness report, optional 15-sec before/after
+            preview.
+          </p>
+          <br />
+          <h3><strong>Use Cases:</strong></h3>
+          <p>YouTube voiceovers, podcast series, trailers, TV & doc pieces.</p>
+          <br />
+        </div>
       </div>
 
       <div class="retro-card">
-        <h2>AI-Driven <strong>Video & Music Content</strong></h2>
-        <br />
-        <p>
-          I <strong>craft</strong> scroll-stopping short videos with consistent AI
-          visuals, strong hooks, and clear captions—plus original AI-generated
-          music when needed.
-        </p>
-        <br />
-        <h3><strong>Services:</strong></h3>
-        <p>
-          Reels/Shorts (9:16), hook scripting, captioning (+ .srt),
-          motion/graphics, Udio music cues, brand-safe sound, export presets.
-        </p>
-        <br />
-        <h3><strong>Deliverables:</strong></h3>
-        <p>
-          Ready-to-publish .mp4 + .srt, thumbnail options, sound design tailored
-          for your brand.
-        </p>
-        <br />
-        <h3><strong>Use Cases:</strong></h3>
-        <p>
-          Product teasers, coaching/edu clips, artist promos, channel growth
-          assets
-        </p>
-        <br />
+        <img src="smartphone_screen.png" alt="Smartphone screen" class="card-image" />
+        <div class="card-content">
+          <h2>AI-Driven <strong>Video & Music Content</strong></h2>
+          <br />
+          <p>
+            I <strong>craft</strong> scroll-stopping short videos with consistent AI
+            visuals, strong hooks, and clear captions—plus original AI-generated
+            music when needed.
+          </p>
+          <br />
+          <h3><strong>Services:</strong></h3>
+          <p>
+            Reels/Shorts (9:16), hook scripting, captioning (+ .srt),
+            motion/graphics, Udio music cues, brand-safe sound, export presets.
+          </p>
+          <br />
+          <h3><strong>Deliverables:</strong></h3>
+          <p>
+            Ready-to-publish .mp4 + .srt, thumbnail options, sound design tailored
+            for your brand.
+          </p>
+          <br />
+          <h3><strong>Use Cases:</strong></h3>
+          <p>
+            Product teasers, coaching/edu clips, artist promos, channel growth
+            assets
+          </p>
+          <br />
+        </div>
       </div>
 
       <div class="retro-card">
-        <h2>Automation & <strong>Media Systems</strong></h2>
-        <br />
-        <p>
-          I build small, reliable <strong>automations</strong> that eliminate repetitive
-          tasks—keeping your content moving while you stay focused on ideas.
-        </p>
-        <br />
-        <h3><strong>Flagship:</strong></h3>
-        <p>
-          <strong>Telegram → Podcast in 72h</strong> capture voice notes, clean audio,
-          auto-assemble episodes, generate cover art, publish via RSS or YouTube
-          Podcast.
-        </p>
-        <br />
-        <h3><strong>Tech Stack:</strong></h3>
-        <p>
-          Make.com, Pipedream—auto-captioning, smart naming, asset routing,
-          scheduled posting, backups, dashboards.
-        </p>
-        <br />
-        <h3><strong>Deliverables:</strong></h3>
-        <p>Working blueprints, Video walkthrough, one month support.</p>
-        <br />
+        <img src="connected_nodes.png" alt="Connected nodes" class="card-image" />
+        <div class="card-content">
+          <h2>Automation & <strong>Media Systems</strong></h2>
+          <br />
+          <p>
+            I build small, reliable <strong>automations</strong> that eliminate repetitive
+            tasks—keeping your content moving while you stay focused on ideas.
+          </p>
+          <br />
+          <h3><strong>Flagship:</strong></h3>
+          <p>
+            <strong>Telegram → Podcast in 72h</strong> capture voice notes, clean audio,
+            auto-assemble episodes, generate cover art, publish via RSS or YouTube
+            Podcast.
+          </p>
+          <br />
+          <h3><strong>Tech Stack:</strong></h3>
+          <p>
+            Make.com, Pipedream—auto-captioning, smart naming, asset routing,
+            scheduled posting, backups, dashboards.
+          </p>
+          <br />
+          <h3><strong>Deliverables:</strong></h3>
+          <p>Working blueprints, Video walkthrough, one month support.</p>
+          <br />
+        </div>
       </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -207,6 +207,39 @@ footer .contact-info p {
   margin: 20px 0;
   padding: 20px;
   width: 100%;
+  display: flex;
+  align-items: flex-start;
+}
+
+.retro-card .card-image {
+  margin: 5%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  clip-path: inset(20% 20% 20% 20%);
+  width: auto;
+  height: auto;
+  max-width: 90%;
+  max-height: 90%;
+}
+
+.retro-card .card-content {
+  flex: 1;
+}
+
+.cards_row .retro-card {
+  flex-direction: column;
+  align-items: center;
+}
+
+.cards_row .retro-card .card-image {
+  width: 90%;
+  height: auto;
+  margin: 5%;
+  max-height: none;
+}
+
+.cards_row .retro-card .card-content {
+  width: 100%;
 }
 
 /* FAQ section inherits retro-card styles */


### PR DESCRIPTION
## Summary
- add and crop images for service cards
- layout images above text in card rows and beside text elsewhere
- avoid stretching cropped images to reduce empty space

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2da49fe4832d999fad62c1beec1f