### PR TITLE
Adjust retro card image styling to prevent excessive cropping

### DIFF
--- a/style.css
+++ b/style.css
@@ -214,8 +214,8 @@ footer .contact-info p {
 .retro-card .card-image {
   margin: 5%;
   aspect-ratio: 1 / 1;
-  object-fit: cover;
-  clip-path: inset(20% 20% 20% 20%);
+  object-fit: contain;
+  clip-path: inset(5% 5% 5% 5%);
 
   width: auto;
   height: auto;


### PR DESCRIPTION
## Summary
- Reduce clip-path inset to 5% for `.retro-card .card-image`
- Switch `object-fit` from `cover` to `contain` to avoid unwanted cropping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3616de04832d9d0f963fa22cd50e