### PR TITLE
Place card images on left at smaller size

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <div class="cards_row">
       <div class="cards_column">
       <div class="retro-card">
+        <img src="audio_waveforms.png" alt="Post-Production" class="card-image" />
         <div class="card-content">
           <h2>Audio & Video <strong>Post-Production</strong></h2>
           <br />
@@ -55,11 +56,11 @@
             I <strong>fix</strong> imperfect content and make it broadcast-grade. From noisy Zooms to full-length documentaries and films
             20+ years in post-production, award-winning films credits.
           </p>
-         </div>
-        <img src="audio_waveforms.png" alt="Post-Production" class="card-image" />
+        </div>
       </div>
 
       <div class="retro-card">
+        <img src="smartphone_screen.png" alt="Media content creation" class="card-image" />
         <div class="card-content">
           <h2>Media <strong>content creation</strong></h2>
           <br />
@@ -68,11 +69,11 @@
             visuals, strong hooks, and visual <em>integrity</em>.
           </p>
         </div>
-        <img src="smartphone_screen.png" alt="Media content creation" class="card-image" />
       </div>
         </div>
       <div class="cards_column">
        <div class="retro-card">
+        <img src="connected_nodes.png" alt="Content automation" class="card-image" />
         <div class="card-content">
           <h2><strong>Automation & Integrations</strong></h2>
           <br />
@@ -80,10 +81,10 @@
             I <strong>automate</strong> repetitive tasks to eliminate your boredom
             And keeping your content moving while you stay focused on ideas.
           </p>
-                  </div>
-       <img src="connected_nodes.png" alt="Content automation" class="card-image" />
+        </div>
       </div>
          <div class="retro-card">
+        <img src="program_code.png" alt="Apps and development" class="card-image" />
         <div class="card-content">
           <h2><strong>Apps and developement</strong></h2>
           <br />
@@ -91,8 +92,7 @@
             I <strong>develope</strong> tools and AI integrations that <em>elevate</em>
             your life performance and reduce your bills
           </p>
-                  </div>
-       <img src="program_code.png" alt="Apps and development" class="card-image" />
+        </div>
       </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -53,14 +53,15 @@ body {
 }
 
 .cards_column .retro-card .card-image {
-  width: 50%;
-  height: 100%;
+  width: 25%;
+  height: 50%;
   object-fit: cover;
   margin: 0;
+  align-self: center;
 }
 
 .cards_column .retro-card .card-content {
-  width: 50%;
+  width: 75%;
   padding: 3%;
 }
 


### PR DESCRIPTION
## Summary
- Shrink images inside cards to half size and position them on the left for a more balanced layout.

## Testing
- `npx --yes prettier --check index.html style.css taudiomagic.html` (fails: 403 Forbidden fetching prettier)


------
https://chatgpt.com/codex/tasks/task_e_68adfb3a3e4c832db599c85ebd488d72