### PR TITLE
Consolidate retro-card styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,10 +44,9 @@ body {
   gap: 20px; /* space between cards */
 }
 
+
 .cards_column .retro-card {
-  display: flex;
   flex-direction: row;
-  width: 100%;
   aspect-ratio: 2 / 1;
   overflow: hidden;
 }
@@ -61,7 +60,6 @@ body {
 }
 
 .cards_column .retro-card .card-content {
-  padding: 3%;
   line-height: 1.4;
   display: -webkit-box;
   -webkit-box-orient: vertical;


### PR DESCRIPTION
## Summary
- Simplify `.cards_column .retro-card` styles to rely on base `.retro-card` rules
- Drop duplicated `card-content` padding and unnecessary properties

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m webbrowser index.html`


------
https://chatgpt.com/codex/tasks/task_e_68af07e059ec832dac8632369732a532