### PR TITLE
Let card images follow text-defined card height

### DIFF
--- a/style.css
+++ b/style.css
@@ -67,14 +67,12 @@ body {
 /* Horizontal card variant */
 .cards-column .card {
   flex-direction: row;
-  aspect-ratio: 2 / 1;
   overflow: hidden;
 }
 
 .cards-column .card img {
   flex: 1;
-  width: 100%;
-  height: 100%;
+  width: 50%;
   object-fit: cover;
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- Allow card height to grow with its text content by removing fixed aspect ratio
- Ensure card images size with cards and retain layout by setting flex and cover properties

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af1847de80832da14b03f1c6bc2d48