### PR TITLE
Use Space Mono for body text and gray Font Awesome icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tony's Media and Automation</title>
     <link
-      href="https://fonts.googleapis.com/css2?family=Anton&family=Orbitron:wght@400;700;900&family=Space+Mono:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap"
       rel="stylesheet"
     />
     <link

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Anton&family=Orbitron:wght@400;700;900&family=Space+Mono:wght@400;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap");
 
 :root {
   --black: #000000;
@@ -17,11 +17,16 @@
 }
 
 body {
-  font-family: sans-serif;
+  font-family: "Space Mono", monospace;
   background: var(--black);
   color: var(--cyan);
   padding-top: 60px;
   padding-bottom: 60px;
+}
+
+.fa-solid,
+.fa-brands {
+  color: var(--light-gray);
 }
 
 /* Content blocks */
@@ -294,7 +299,7 @@ footer .contact-info p {
   display: flex;
   justify-content: space-between;
   margin-bottom: 10px;
-  font-family: "Orbitron", sans-serif;
+  font-family: "Space Mono", monospace;
   font-size: 0.9rem;
 }
 

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -19,7 +19,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tony's Audio Magic</title>
     <link
-      href="https://fonts.googleapis.com/css2?family=Anton&family=Orbitron:wght@400;700;900&family=Space+Mono:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap"
       rel="stylesheet"
     />
     <link


### PR DESCRIPTION
## Summary
- Drop Orbitron and load only Anton and Space Mono
- Use Space Mono for all non-heading text
- Style Font Awesome icons with a light gray color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a38a278832d8d5291bdc82695d3