### PR TITLE
Embed Airtable form and route CTA buttons to it

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,21 +106,22 @@
     </div>
     <div class="cta-buttons">
       <a
-        href="mailto:contentmage@tonysautomedia.com?subject=Service%20Inquiry&body=Hi%20Tony%2C%20I'm%20interested%20in%20your%20audio%20services.%20Please%20let%20me%20know%20more."
-        target="_blank"
+        href="#contact-form"
         class="retro-button"
-        aria-label="Email"
+        aria-label="Contact Form"
       >
         <i class="fa-solid fa-envelope"></i>
       </a>
       <a
-        href="https://wa.me/972534384116"
-        target="_blank"
+        href="#contact-form"
         class="retro-button"
-        aria-label="WhatsApp"
+        aria-label="Contact Form"
       >
         <i class="fa-brands fa-whatsapp"></i>
       </a>
+    </div>
+    <div id="contact-form">
+      <iframe class="airtable-embed" src="https://airtable.com/embed/app6xxZBV3HoNgZ1V/pagc0YMK5v8TjLRc6/form" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
     </div>
 
     <footer>

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -212,21 +212,22 @@
 
     <div class="cta-buttons">
       <a
-        href="mailto:contentmage@tonysautomedia.com?subject=Service%20Inquiry&body=Hi%20Tony%2C%20I'm%20interested%20in%20your%20audio%20services.%20Please%20let%20me%20know%20more."
-        target="_blank"
+        href="#contact-form"
         class="retro-button"
-        aria-label="Email"
+        aria-label="Contact Form"
       >
         <i class="fa-solid fa-envelope"></i>
       </a>
       <a
-        href="https://wa.me/972534384116"
-        target="_blank"
+        href="#contact-form"
         class="retro-button"
-        aria-label="WhatsApp"
+        aria-label="Contact Form"
       >
         <i class="fa-brands fa-whatsapp"></i>
       </a>
+    </div>
+    <div id="contact-form">
+      <iframe class="airtable-embed" src="https://airtable.com/embed/app6xxZBV3HoNgZ1V/pagc0YMK5v8TjLRc6/form" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
     </div>
 
     <footer>


### PR DESCRIPTION
## Summary
- Embed Airtable contact form at bottom of main pages
- Point CTA buttons to the in-page form instead of external links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b463fa8e3c832d867679871d32733d