### PR TITLE
Restrict contact form to aivideooffer page

### DIFF
--- a/aivideooffer_ru.htm
+++ b/aivideooffer_ru.htm
@@ -473,7 +473,9 @@
                         <p>+1500₪ за вертикальное + горизонтальное видео</p>
                     </div>
 
-                   <iframe class="airtable-embed" src="https://airtable.com/embed/app6xxZBV3HoNgZ1V/pagc0YMK5v8TjLRc6/form" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+                   <div id="contact-form">
+                       <iframe class="airtable-embed" src="https://airtable.com/embed/app6xxZBV3HoNgZ1V/pagc0YMK5v8TjLRc6/form" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+                   </div>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -106,14 +106,14 @@
     </div>
     <div class="cta-buttons">
       <a
-        href="#contact-form"
+        href="aivideooffer_ru.htm#contact-form"
         class="retro-button"
         aria-label="Contact Form"
       >
         <i class="fa-solid fa-envelope"></i>
       </a>
       <a
-        href="#contact-form"
+        href="aivideooffer_ru.htm#contact-form"
         class="retro-button"
         aria-label="Contact Form"
       >

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -212,22 +212,19 @@
 
     <div class="cta-buttons">
       <a
-        href="#contact-form"
+        href="aivideooffer_ru.htm#contact-form"
         class="retro-button"
         aria-label="Contact Form"
       >
         <i class="fa-solid fa-envelope"></i>
       </a>
       <a
-        href="#contact-form"
+        href="aivideooffer_ru.htm#contact-form"
         class="retro-button"
         aria-label="Contact Form"
       >
         <i class="fa-brands fa-whatsapp"></i>
       </a>
-    </div>
-    <div id="contact-form">
-      <iframe class="airtable-embed" src="https://airtable.com/embed/app6xxZBV3HoNgZ1V/pagc0YMK5v8TjLRc6/form" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
     </div>
 
     <footer>


### PR DESCRIPTION
## Summary
- Link CTA buttons on index and audio magic pages to aivideooffer form
- Remove embedded form from taudiomagic page
- Expose aivideooffer form via `contact-form` anchor for external links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b46793a198832daa37caba3c8e0ed7