### PR TITLE
Scale down mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -521,3 +521,12 @@ footer .contact-info p {
     border-radius: 60% 40% 30% 70% / 60% 50% 40% 30%;
   }
 }
+/* Mobile: scale everything to half size */
+@media (max-width: 600px) {
+  body {
+    transform: scale(0.5);
+    transform-origin: top left;
+    width: 200%;
+    height: 200%;
+  }
+}


### PR DESCRIPTION
## Summary
- Scale the entire site to 50% on screens up to 600px to shrink fonts and elements for the mobile view.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8f6efc60832d869422b1f44413b8