### PR TITLE
Improve mobile layout of portfolio cards

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -49,6 +49,7 @@
     <div class="cards-row">
       <div class="cards-column">
         <div class="card">
+          <h3>AI Commercial</h3>
           <iframe
             width="560"
             height="315"
@@ -59,8 +60,7 @@
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
           ></iframe>
-          <ul>
-            <h3>AI Commercial</h3>
+          <ul class="skills">
             <li>Video editing</li>
             <li>Motion graphics</li>
             <li>Sound design and mixing</li>
@@ -69,9 +69,10 @@
             <li>AI music generation</li>
             <li>AI voiceover generation</li>
             <li>JSON Prompt engineering</li>
-          </ul>        
+          </ul>
         </div>
         <div class="card">
+          <h3>Explainer video</h3>
           <iframe
             width="560"
             height="315"
@@ -82,8 +83,7 @@
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
           ></iframe>
-          <ul>
-            <h3>Explainer video</h3>
+          <ul class="skills">
             <li>Video editing</li>
             <li>Motion graphics</li>
             <li>Sound design</li>
@@ -95,6 +95,7 @@
       </div>
       <div class="cards-column">
         <div class="card">
+          <h3>Video review</h3>
           <iframe
             width="560"
             height="315"
@@ -105,8 +106,7 @@
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
           ></iframe>
-          <ul>
-            <h3>Video review</h3>
+          <ul class="skills">
             <li>Video editing</li>
             <li>Motion graphics</li>
             <li>Sound design and mixing</li>
@@ -116,6 +116,7 @@
           </ul>
         </div>
         <div class="card">
+          <h3>Documentary production</h3>
           <iframe
             width="560"
             height="315"
@@ -126,8 +127,7 @@
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
           ></iframe>
-          <ul>
-            <h3>Documentary production</h3>
+          <ul class="skills">
             <li>Video editing</li>
             <li>Motion graphics</li>
             <li>Sound design and mixing</li>

--- a/style.css
+++ b/style.css
@@ -94,6 +94,22 @@ body {
   .cards-row {
     flex-direction: column;
   }
+  .cards-column .card {
+    flex-direction: column;
+    align-items: center;
+  }
+  .card h3 {
+    text-align: center;
+    width: 100%;
+    margin-bottom: 10px;
+  }
+  .card iframe {
+    width: 100%;
+    height: auto;
+  }
+  .card .skills {
+    margin-top: 10px;
+  }
 }
 
 header:not(.main-nav) h1 {


### PR DESCRIPTION
## Summary
- Reordered portfolio cards to show title, video, then skills
- Added responsive CSS to center card content on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd228b1ac832db068d73c6f2afa29