### PR TITLE
Make portfolio video embeds responsive and padded

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -51,8 +51,6 @@
         <div class="card">
           <h3>AI Commercial</h3>
           <iframe
-            width="560"
-            height="315"
             src="https://www.youtube.com/embed/GuHLzmP-xZM?si=kiJv0iSBKVFYjuvb&amp;controls=0"
             title="Elvishoe - The Magic of Comfort"
             frameborder="0"
@@ -74,8 +72,6 @@
         <div class="card">
           <h3>Explainer video</h3>
           <iframe
-            width="560"
-            height="315"
             src="https://www.youtube.com/embed/9qeGSeha-LU?si=IDDWZhn9TedBIHfl&amp;controls=0"
             title="Sound Design Explained"
             frameborder="0"
@@ -97,8 +93,6 @@
         <div class="card">
           <h3>Video review</h3>
           <iframe
-            width="560"
-            height="315"
             src="https://www.youtube.com/embed/JzXSnLSNEqQ?si=Btwrnq-sYxhtq4AE&amp;controls=0"
             title="NotebookLM"
             frameborder="0"
@@ -118,8 +112,6 @@
         <div class="card">
           <h3>Documentary production</h3>
           <iframe
-            width="560"
-            height="315"
             src="https://www.youtube.com/embed/wr8Q-fQHlRs?si=hYBLh7B38Zai1QWq&amp;controls=0"
             title="Mikhoels suitcase"
             frameborder="0"

--- a/style.css
+++ b/style.css
@@ -22,6 +22,8 @@ body {
   color: var(--cyan);
   padding-top: 60px;
   padding-bottom: 60px;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .fa-solid,
@@ -69,6 +71,13 @@ body {
   padding: 3%;
 }
 
+.card iframe {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16/9;
+  display: block;
+}
+
 /* Horizontal card variant */
 .cards-column .card {
   flex-direction: row;
@@ -102,10 +111,6 @@ body {
     text-align: center;
     width: 100%;
     margin-bottom: 10px;
-  }
-  .card iframe {
-    width: 100%;
-    height: auto;
   }
   .card .skills {
     margin-top: 10px;


### PR DESCRIPTION
## Summary
- Apply consistent responsive styles to card iframes
- Add horizontal padding to body to prevent edge-to-edge content
- Remove fixed width/height from portfolio embeds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be824be4b4832d9d79db47d05188e9