### PR TITLE
Refine mobile layout with flexible units

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,8 +20,8 @@ body {
   font-family: "Space Mono", monospace;
   background: var(--black);
   color: var(--cyan);
-  padding-top: 60px;
-  padding-bottom: 60px;
+  padding-top: 6vh;
+  padding-bottom: 6vh;
   padding-left: 1rem;
   padding-right: 1rem;
 }
@@ -40,16 +40,17 @@ body {
   color: var(--cyan);
 }
 /* Card layout */
+
 .cards-row {
   display: flex;
-  gap: 20px; /* space between columns */
+  gap: 2%; /* space between columns */
 }
 
 .cards-column {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 20px; /* space between cards */
+  gap: 2%; /* space between cards */
 }
 
 /* Card component */
@@ -59,7 +60,7 @@ body {
   border: none;
   border-radius: 0;
   box-shadow: none;
-  margin: 20px 0;
+  margin: 2% 0;
   padding: 0;
   width: 100%;
   display: flex;
@@ -99,7 +100,39 @@ body {
   overflow: hidden; /* extra text is truncated */
 }
 
-@media (max-width: 600px) {
+@media (pointer: coarse) {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  ul,
+  ol {
+    margin-left: 1%;
+    margin-right: 1%;
+    width: 98%;
+  }
+  .card,
+  .card iframe {
+    margin: 1%;
+    width: 98%;
+  }
+  footer {
+    display: none;
+  }
+  .cta-buttons {
+    top: auto;
+    bottom: 2vh;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    flex-direction: row;
+  }
+}
+
+@media (pointer: coarse) and (orientation: portrait) {
   .cards-row {
     flex-direction: column;
   }
@@ -110,10 +143,24 @@ body {
   .card h3 {
     text-align: center;
     width: 100%;
-    margin-bottom: 10px;
+    margin-bottom: 1vh;
   }
   .card .skills {
-    margin-top: 10px;
+    margin-top: 1vh;
+  }
+}
+
+@media (pointer: coarse) and (orientation: landscape) {
+  .cards-row {
+    flex-direction: row;
+  }
+  .cards-column .card {
+    flex-direction: row;
+  }
+  .card h3 {
+    text-align: left;
+    width: auto;
+    margin-bottom: 0;
   }
 }
 
@@ -124,7 +171,7 @@ header:not(.main-nav) h1 {
 
 .audio-player-simple {
   display: flex;
-  gap: 10px;
+  gap: 1%;
 }
 
 .audio-track {
@@ -132,7 +179,7 @@ header:not(.main-nav) h1 {
   font-family: "Space Mono", monospace;
   background-color: var(--light-gray);
   color: var(--cyan);
-  padding-top: 60px;
+  padding-top: 6vh;
 }
 
 h1,
@@ -155,11 +202,11 @@ h6 {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  padding: 10px 20px;
+  padding: 1% 2%;
   background: linear-gradient(to bottom, var(--magenta), transparent);
   z-index: 1000;
   direction: ltr;
-  gap: 10px;
+  gap: 1%;
 }
 
 .main-nav .home-link {
@@ -170,8 +217,8 @@ h6 {
   background-color: var(--indigo);
   color: var(--cyan);
   text-decoration: none;
-  padding: 10px 20px;
-  border-radius: 4px;
+  padding: 1% 2%;
+  border-radius: 0.25rem;
   transition: background-color 0.3s;
 }
 
@@ -186,12 +233,12 @@ h6 {
 .video-thumb {
   width: 100%;
   height: auto;
-  border-radius: 15px;
+  border-radius: 1rem;
 }
 /* Footer */
 footer {
   background: linear-gradient(to top, var(--magenta), transparent);
-  padding: 20px;
+  padding: 2%;
   color: var(--cyan);
   display: flex;
   justify-content: space-between;
@@ -211,7 +258,7 @@ footer .contact-info {
 }
 
 footer .contact-info p {
-  margin: 2px 0;
+  margin: 0.2% 0;
   line-height: 1.2;
   color: var(--cyan);
   font-size: 0.9em;
@@ -219,7 +266,7 @@ footer .contact-info p {
 
 /* Header tagline */
 .tagline {
-  margin-top: 10px;
+  margin-top: 1%;
   font-family: "Space Mono", monospace;
   font-size: 1.2rem;
   color: var(--cyan);
@@ -231,13 +278,13 @@ footer .contact-info p {
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  gap: 4px;
-  height: 40px;
-  margin: 20px 0;
+  gap: 0.5%;
+  height: 5vh;
+  margin: 2% 0;
 }
 
 .sound-wave {
-  width: 4px;
+  width: 0.25rem;
   background: var(--magenta);
   animation: wave 1s infinite ease-in-out;
 }
@@ -264,10 +311,10 @@ footer .contact-info p {
 @keyframes wave {
   0%,
   100% {
-    height: 5px;
+    height: 0.5vh;
   }
   50% {
-    height: 40px;
+    height: 5vh;
   }
 }
 
@@ -278,33 +325,33 @@ footer .contact-info p {
 
 .faq .question {
   font-weight: bold;
-  margin-top: 15px;
+  margin-top: 1.5%;
 }
 
 /* Audio demo */
 .audio-demo {
-  margin-top: 20px;
+  margin-top: 2%;
 }
 
 .audio-player-container {
-  margin-top: 15px;
+  margin-top: 1.5%;
 }
 
 .track-buttons {
   display: flex;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: 1%;
+  margin-bottom: 1%;
 }
 
 .track-btn {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.5%;
   background: var(--indigo);
   color: var(--cyan);
   border: none;
-  padding: 8px 12px;
-  border-radius: 4px;
+  padding: 0.5% 0.75%;
+  border-radius: 0.25rem;
   cursor: pointer;
   transition: background-color 0.3s;
 }
@@ -317,15 +364,15 @@ footer .contact-info p {
 .audio-player {
   background: var(--black);
   color: var(--cyan);
-  padding: 15px;
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  padding: 1.5%;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.2);
 }
 
 .player-info {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 10px;
+  margin-bottom: 1%;
   font-family: "Space Mono", monospace;
   font-size: 0.9rem;
 }
@@ -333,14 +380,14 @@ footer .contact-info p {
 .player-controls {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 1%;
 }
 
 .play-pause-btn {
   background: var(--cyan);
   border: none;
-  border-radius: 4px;
-  padding: 8px 12px;
+  border-radius: 0.25rem;
+  padding: 0.5% 0.75%;
   cursor: pointer;
 }
 
@@ -350,9 +397,9 @@ footer .contact-info p {
 
 .progress-bar {
   width: 100%;
-  height: 6px;
+  height: 0.6vh;
   background: var(--dark-gray);
-  border-radius: 3px;
+  border-radius: 0.2rem;
   overflow: hidden;
 }
 
@@ -365,17 +412,17 @@ footer .contact-info p {
 .volume-container {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.5%;
 }
 
 .volume-slider {
-  width: 80px;
+  width: 5rem;
 }
 
 /* Video placeholder */
 .video-placeholder {
-  max-width: 560px;
-  margin: 40px auto;
+  max-width: 35rem;
+  margin: 4% auto;
 }
 
 .video-wrapper {
@@ -409,7 +456,7 @@ footer .contact-info p {
   align-items: center;
   opacity: 0;
   transition: opacity 0.3s;
-  border-radius: 15px;
+  border-radius: 1rem;
 }
 
 .video-thumbnail:hover .play-overlay {
@@ -425,24 +472,24 @@ footer .contact-info p {
 .cta-buttons {
   position: fixed;
   top: 50%;
-  right: 20px;
+  right: 2%;
   transform: translateY(-50%);
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 1.5%;
   margin: 0;
   z-index: 1000;
 }
 
 .cta-buttons .retro-button {
-  width: 40px;
-  height: 40px;
+  width: 5vmin;
+  height: 5vmin;
   padding: 0;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
+  font-size: 1.125rem;
   opacity: 0.6;
   transition: opacity 0.3s, transform 0.3s;
 }
@@ -460,13 +507,13 @@ footer .contact-info p {
   0%,
   100% {
     transform: scale(1);
-    box-shadow: 0 4px 0 var(--indigo);
+    box-shadow: 0 0.25rem 0 var(--indigo);
   }
   50% {
     transform: scale(1.5);
     box-shadow:
-      0 4px 0 var(--indigo),
-      0 0 20px 20px var(--light-gray);
+      0 0.25rem 0 var(--indigo),
+      0 0 1.25rem 1.25rem var(--light-gray);
   }
 }
 
@@ -474,9 +521,9 @@ footer .contact-info p {
   background: var(--magenta);
   color: var(--cyan);
   text-decoration: none;
-  padding: 15px 25px;
-  border-radius: 4px;
-  box-shadow: 0 4px 0 var(--indigo);
+  padding: 1.5% 2.5%;
+  border-radius: 0.25rem;
+  box-shadow: 0 0.25rem 0 var(--indigo);
   transition:
     background-color 0.3s,
     transform 0.1s,
@@ -488,8 +535,8 @@ footer .contact-info p {
 }
 
 .retro-button:active {
-  transform: translateY(2px);
-  box-shadow: 0 2px 0 var(--indigo);
+  transform: translateY(0.125rem);
+  box-shadow: 0 0.125rem 0 var(--indigo);
 }
 
 /* Animated background */
@@ -509,7 +556,7 @@ footer .contact-info p {
   margin: -45vmax 0 0 -45vmax;
   background: radial-gradient(circle, var(--deep-purple) 0%, transparent 80%);
   mix-blend-mode: lighten;
-  filter: blur(120px);
+  filter: blur(7.5rem);
   opacity: 0.7;
   transition: transform 30s ease-in-out;
   animation: morph 20s infinite alternate ease-in-out;
@@ -540,14 +587,5 @@ footer .contact-info p {
   }
   100% {
     border-radius: 60% 40% 30% 70% / 60% 50% 40% 30%;
-  }
-}
-/* Mobile: scale everything to half size */
-@media (max-width: 600px) {
-  body {
-    transform: scale(0.5);
-    transform-origin: top left;
-    width: 200%;
-    height: 200%;
   }
 }


### PR DESCRIPTION
## Summary
- Target touch devices with orientation-based media queries instead of pixel breakpoints
- Add 1% side margins so text, cards, and videos scale across the screen
- Position contact buttons using relative units and hide the footer on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c15cea3e08832da199f73742ce7ced