### PR TITLE
Ensure navigation button text turns black on hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -219,12 +219,12 @@ h6 {
   text-decoration: none;
   padding: 1% 2%;
   border-radius: 0.25rem;
-  transition: background-color 0.3s;
+  transition: background-color 0.3s, color 0.3s;
 }
 
 .nav-btn:hover {
   background-color: var(--cyan);
-  color: var(--black);
+  color: var(--black) !important;
 }
 
 .nav-btn:hover .fa-solid,


### PR DESCRIPTION
## Summary
- Force navigation button text to switch to black when hovered and add smooth color transition

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c21392b234832d96ec08d5faa0992f