### PR TITLE
fix: show two portfolio cards per row on desktop

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -27,7 +27,7 @@
     />
     <link rel="stylesheet" href="style.css" />
   </head>
-  <body>
+  <body class="portfolio-page">
     <header class="main-nav">
       <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
       <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>

--- a/style.css
+++ b/style.css
@@ -100,6 +100,24 @@ body {
   overflow: hidden; /* extra text is truncated */
 }
 
+/* Portfolio page adjustments */
+.portfolio-page .card {
+  flex-direction: column;
+  overflow: visible;
+}
+
+@media (pointer: fine) {
+  .portfolio-page .cards-row {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2%;
+  }
+
+  .portfolio-page .cards-column {
+    display: contents;
+  }
+}
+
 @media (pointer: coarse) {
   h1,
   h2,
@@ -219,7 +237,9 @@ h6 {
   text-decoration: none;
   padding: 1% 2%;
   border-radius: 0.25rem;
-  transition: background-color 0.3s, color 0.3s;
+  transition:
+    background-color 0.3s,
+    color 0.3s;
 }
 
 .nav-btn:hover {
@@ -497,7 +517,9 @@ footer .contact-info p {
   justify-content: center;
   font-size: 1.125rem;
   opacity: 0.6;
-  transition: opacity 0.3s, transform 0.3s;
+  transition:
+    opacity 0.3s,
+    transform 0.3s;
 }
 
 .cta-buttons .retro-button:hover {
@@ -580,7 +602,6 @@ footer .contact-info p {
   transition: transform 30s ease-in-out;
   animation: morph 20s infinite alternate ease-in-out;
 }
-
 
 .blob:nth-child(1) {
   transform: translate(-30vw, -30vh);


### PR DESCRIPTION
## Summary
- convert portfolio layout to a two-column grid on desktop
- flatten column wrappers with `display: contents` to keep markup while gridifying layout

## Testing
- `npx prettier --check style.css portfolio.html`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c218df9bd0832da4ed9f30585d0c85