### PR TITLE
Add mobile-friendly pages and portfolio grid layout

### DIFF
--- a/index_mobile.html
+++ b/index_mobile.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0X2H6SQNQP"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-0X2H6SQNQP');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tony's Media and Automation</title>
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+    <link rel="stylesheet" href="style-mobile.css" />
+  </head>
+  <body>
+    <header class="main-nav">
+      <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
+      <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+      <a href="portfolio_mobile.html" class="nav-btn">Portfolio</a>
+      <a href="index_mobile.html" class="nav-btn home-link">Home</a>
+    </header>
+    <div class="blob-bg">
+      <div class="blob"></div>
+      <div class="blob"></div>
+      <div class="blob"></div>
+    </div>
+    <header>
+      <h1>Tony's Media and Automation</h1>
+      <div class="tagline">From raw idea to <strong>automated content!</strong></div>
+    </header>
+    <div class="cards-row">
+      <div class="cards-column">
+        <div class="card">
+            <img src="audio_waveforms.png" alt="Post-Production" />
+          <div class="card-content">
+          <h2>Audio & Video <strong>Post-Production</strong></h2>
+          <br />
+          <p>
+            I <strong>fix</strong> imperfect content and make it broadcast-grade. From noisy Zooms to full-length documentaries and films
+            20+ years in post-production, award-winning films credits.
+          </p>
+        </div>
+      </div>
+        <div class="card">
+            <img src="smartphone_screen.png" alt="Media content creation" />
+          <div class="card-content">
+          <h2>Media <strong>content creation</strong></h2>
+          <br />
+          <p>
+            I <strong>craft</strong> scroll-stopping short videos with consistent AI
+            visuals, strong hooks, and visual <em>integrity</em>.
+          </p>
+        </div>
+      </div>
+      </div>
+      <div class="cards-column">
+       <div class="card">
+        <img src="connected_nodes.png" alt="Content automation" />
+        <div class="card-content">
+          <h2><strong>Automation & Integrations</strong></h2>
+          <br />
+          <p>
+            I <strong>automate</strong> repetitive tasks to eliminate your boredom
+            And keeping your content moving while you stay focused on ideas.
+          </p>
+        </div>
+      </div>
+         <div class="card">
+        <img src="program_code.png" alt="Apps and development" />
+        <div class="card-content">
+          <h2><strong>Apps and developement</strong></h2>
+          <br />
+          <p>
+            I <strong>develope</strong> tools and AI integrations that <em>elevate</em>
+            your life performance and reduce your bills
+          </p>
+        </div>
+      </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-content">
+        <h3><strong>Who I am?:</strong></h3>
+        I’m a media producer (20+ years) and creative automator (a little less) who blends pro-level audio,
+        visuals, practical automation and AI workflow enhancment. I help creators, startups,
+        and small teams ship more, get better outcome, and publish faster.<br />
+      </div>
+    </div>
+    <div class="cta-buttons">
+      <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="Email">
+        <i class="fa-solid fa-envelope"></i> Write me an email
+      </a>
+      <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="WhatsApp">
+        <i class="fa-brands fa-whatsapp"></i> Write me on WhatsApp
+      </a>
+    </div>
+    <footer>
+      <p>© 2025 Tony's Automation and Media</p>
+      <div class="contact-info">
+        <p>אנטון זצ'וסוב</p>
+        <p>בני בנימין 3 דירה 28</p>
+        <p>נתניה, 4201959</p>
+        <p>contentmage@tonysautomedia.com</p>
+      </div>
+    </footer>
+    <script>
+      const ctaButtons = document.querySelectorAll('.cta-buttons .retro-button');
+      function pulseButtons(){
+        ctaButtons.forEach((btn)=>btn.classList.add('pulse'));
+        setTimeout(()=>{ctaButtons.forEach((btn)=>btn.classList.remove('pulse'));},10000);
+      }
+      pulseButtons();
+      setInterval(pulseButtons,60000);
+    </script>
+    <script>
+      const blobs = document.querySelectorAll('.blob');
+      function moveBlob(b){
+        const x = Math.random()*100-50;
+        const y = Math.random()*100-50;
+        b.style.transform = `translate(${x}vw, ${y}vh)`;
+      }
+      blobs.forEach((b)=>{
+        setTimeout(()=>moveBlob(b),100);
+        setInterval(()=>moveBlob(b),30000);
+      });
+    </script>
+  </body>
+</html>

--- a/portfolio_mobile.html
+++ b/portfolio_mobile.html
@@ -2,61 +2,40 @@
 <html lang="en">
   <head>
     <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-0X2H6SQNQP"
-    ></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0X2H6SQNQP"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "G-0X2H6SQNQP");
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-0X2H6SQNQP');
     </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio - Tony's Media and Automation</title>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
-    />
-    <link rel="stylesheet" href="style.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+    <link rel="stylesheet" href="style-mobile.css" />
   </head>
   <body class="portfolio-page">
     <header class="main-nav">
       <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
       <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
-      <a href="portfolio.html" class="nav-btn">Portfolio</a>
-      <a href="index.html" class="nav-btn home-link">Home</a>
+      <a href="portfolio_mobile.html" class="nav-btn">Portfolio</a>
+      <a href="index_mobile.html" class="nav-btn home-link">Home</a>
     </header>
-
     <div class="blob-bg">
       <div class="blob"></div>
       <div class="blob"></div>
       <div class="blob"></div>
     </div>
-
     <header>
       <h1>Portfolio</h1>
       <div class="tagline">Selected works and experiments</div>
     </header>
-
     <div class="portfolio-grid">
       <div class="pair">
         <div class="card">
-          <iframe
-            src="https://www.youtube.com/embed/GuHLzmP-xZM?si=kiJv0iSBKVFYjuvb&amp;controls=0"
-            title="Elvishoe - The Magic of Comfort"
-            frameborder="0"
-            allow="encrypted-media; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
+          <iframe src="https://www.youtube.com/embed/GuHLzmP-xZM?si=kiJv0iSBKVFYjuvb&amp;controls=0" title="Elvishoe - The Magic of Comfort" frameborder="0" allow="encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </div>
         <div class="card">
           <h3>AI Commercial</h3>
@@ -74,14 +53,7 @@
       </div>
       <div class="pair">
         <div class="card">
-          <iframe
-            src="https://www.youtube.com/embed/9qeGSeha-LU?si=IDDWZhn9TedBIHfl&amp;controls=0"
-            title="Sound Design Explained"
-            frameborder="0"
-            allow="encrypted-media; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
+          <iframe src="https://www.youtube.com/embed/9qeGSeha-LU?si=IDDWZhn9TedBIHfl&amp;controls=0" title="Sound Design Explained" frameborder="0" allow="encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </div>
         <div class="card">
           <h3>Explainer video</h3>
@@ -97,14 +69,7 @@
       </div>
       <div class="pair">
         <div class="card">
-          <iframe
-            src="https://www.youtube.com/embed/JzXSnLSNEqQ?si=Btwrnq-sYxhtq4AE&amp;controls=0"
-            title="NotebookLM"
-            frameborder="0"
-            allow="encrypted-media; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
+          <iframe src="https://www.youtube.com/embed/JzXSnLSNEqQ?si=Btwrnq-sYxhtq4AE&amp;controls=0" title="NotebookLM" frameborder="0" allow="encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </div>
         <div class="card">
           <h3>Video review</h3>
@@ -120,14 +85,7 @@
       </div>
       <div class="pair">
         <div class="card">
-          <iframe
-            src="https://www.youtube.com/embed/wr8Q-fQHlRs?si=hYBLh7B38Zai1QWq&amp;controls=0"
-            title="Mikhoels suitcase"
-            frameborder="0"
-            allow="encrypted-media; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
+          <iframe src="https://www.youtube.com/embed/wr8Q-fQHlRs?si=hYBLh7B38Zai1QWq&amp;controls=0" title="Mikhoels suitcase" frameborder="0" allow="encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </div>
         <div class="card">
           <h3>Documentary production</h3>
@@ -142,24 +100,14 @@
         </div>
       </div>
     </div>
-
     <div class="cta-buttons">
-      <a
-        href="aivideooffer.htm#contact-form"
-        class="retro-button"
-        aria-label="Contact Form"
-      >
-        <i class="fa-solid fa-envelope"></i>
+      <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="Email">
+        <i class="fa-solid fa-envelope"></i> Write me an email
       </a>
-      <a
-        href="aivideooffer.htm#contact-form"
-        class="retro-button"
-        aria-label="Contact Form"
-      >
-        <i class="fa-brands fa-whatsapp"></i>
+      <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="WhatsApp">
+        <i class="fa-brands fa-whatsapp"></i> Write me on WhatsApp
       </a>
     </div>
-
     <footer>
       <p>© 2025 Tony's Automation and Media</p>
       <div class="contact-info">
@@ -169,30 +117,25 @@
         <p>contentmage@tonysautomedia.com</p>
       </div>
     </footer>
-
     <script>
-      const ctaButtons = document.querySelectorAll(
-        ".cta-buttons .retro-button",
-      );
-      function pulseButtons() {
-        ctaButtons.forEach((btn) => btn.classList.add("pulse"));
-        setTimeout(() => {
-          ctaButtons.forEach((btn) => btn.classList.remove("pulse"));
-        }, 10000);
+      const ctaButtons = document.querySelectorAll('.cta-buttons .retro-button');
+      function pulseButtons(){
+        ctaButtons.forEach((btn)=>btn.classList.add('pulse'));
+        setTimeout(()=>{ctaButtons.forEach((btn)=>btn.classList.remove('pulse'));},10000);
       }
       pulseButtons();
-      setInterval(pulseButtons, 60000);
+      setInterval(pulseButtons,60000);
     </script>
     <script>
-      const blobs = document.querySelectorAll(".blob");
-      function moveBlob(b) {
-        const x = Math.random() * 100 - 50;
-        const y = Math.random() * 100 - 50;
+      const blobs = document.querySelectorAll('.blob');
+      function moveBlob(b){
+        const x = Math.random()*100-50;
+        const y = Math.random()*100-50;
         b.style.transform = `translate(${x}vw, ${y}vh)`;
       }
-      blobs.forEach((b) => {
-        setTimeout(() => moveBlob(b), 100);
-        setInterval(() => moveBlob(b), 30000);
+      blobs.forEach((b)=>{
+        setTimeout(()=>moveBlob(b),100);
+        setInterval(()=>moveBlob(b),30000);
       });
     </script>
   </body>

--- a/style-mobile.css
+++ b/style-mobile.css
@@ -1,0 +1,56 @@
+@import url("style.css");
+
+/* Flatten complex layouts for mobile */
+.cards-row,
+.portfolio-grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.cards-column,
+.pair {
+  display: contents;
+}
+
+.cards-row .card,
+.portfolio-grid .card {
+  width: 100%;
+}
+
+@media (orientation: landscape) {
+  .cards-row,
+  .portfolio-grid {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .cards-row .card,
+  .portfolio-grid .card {
+    width: 50%;
+  }
+}
+
+/* Mobile contact buttons */
+.cta-buttons {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 1rem;
+  z-index: 1000;
+}
+
+.cta-buttons .retro-button {
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  border-radius: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  opacity: 1;
+}
+
+.cta-buttons .retro-button i {
+  margin-right: 0.25rem;
+}

--- a/style.css
+++ b/style.css
@@ -106,15 +106,24 @@ body {
   overflow: visible;
 }
 
+.portfolio-grid,
+.portfolio-grid .pair {
+  display: flex;
+  flex-direction: column;
+  gap: 2%;
+}
+
 @media (pointer: fine) {
-  .portfolio-page .cards-row {
+  .portfolio-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 2%;
   }
 
-  .portfolio-page .cards-column {
-    display: contents;
+  .portfolio-grid .pair {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2%;
   }
 }
 


### PR DESCRIPTION
## Summary
- add orientation-aware `index_mobile.html` and `portfolio_mobile.html` using new `style-mobile.css`
- rework `portfolio.html` into an 8-card grid
- position mobile contact buttons at bottom center with text labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c21e4ab9e8832d8c20069249c172c4