### PR TITLE
Revamp navigation, add About Me pages and unified footer

### DIFF
--- a/aboutme.html
+++ b/aboutme.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0X2H6SQNQP"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} 
+      gtag('js', new Date());
+      gtag('config', 'G-0X2H6SQNQP');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Me - Tony's Media and Automation</title>
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+    <link rel="stylesheet" href="style.css" />
+    <script src="mobile-redirect.js"></script>
+  </head>
+  <body>
+    <header class="main-nav">
+      <div class="nav-dropdown">
+        <a href="#" class="nav-btn">Offers</a>
+        <div class="dropdown-content">
+          <a href="taudiomagic.html">Audio Magic</a>
+          <a href="https://tonys.lovable.app">Automation</a>
+          <a href="aivideooffer.htm">AI Video Offer</a>
+        </div>
+      </div>
+      <a href="portfolio.html" class="nav-btn">Portfolio</a>
+      <a href="aboutme.html" class="nav-btn">About Me</a>
+      <a href="index.html" class="nav-btn home-link">Home</a>
+    </header>
+    <div class="blob-bg">
+      <div class="blob"></div>
+      <div class="blob"></div>
+      <div class="blob"></div>
+    </div>
+    <header>
+      <h1>About Me</h1>
+    </header>
+    <div class="card">
+      <div class="card-content">
+        <h3><strong>Who I am?:</strong></h3>
+        I’m a media producer (20+ years) and creative automator (a little less) who blends pro-level audio,
+        visuals, practical automation and AI workflow enhancment. I help creators, startups,
+        and small teams ship more, get better outcome, and publish faster.<br />
+      </div>
+    </div>
+    <div class="legal-info">
+      <p>אנטון זצ'וסוב</p>
+      <p>בני בנימין 3 דירה 28</p>
+      <p>נתניה, 4201959</p>
+      <p>contentmage@tonysautomedia.com</p>
+    </div>
+    <div class="cta-buttons">
+      <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="Contact Form">
+        <i class="fa-solid fa-envelope"></i>
+      </a>
+      <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="Contact Form">
+        <i class="fa-brands fa-whatsapp"></i>
+      </a>
+    </div>
+    <footer>
+      <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
+      </div>
+    </footer>
+    <script src="nav.js"></script>
+    <script>
+      const ctaButtons = document.querySelectorAll('.cta-buttons .retro-button');
+      function pulseButtons(){
+        ctaButtons.forEach(btn=>btn.classList.add('pulse'));
+        setTimeout(()=>{ctaButtons.forEach(btn=>btn.classList.remove('pulse'));},10000);
+      }
+      pulseButtons();
+      setInterval(pulseButtons,60000);
+    </script>
+    <script>
+      const blobs = document.querySelectorAll('.blob');
+      function moveBlob(b){
+        const x = Math.random()*100-50;
+        const y = Math.random()*100-50;
+        b.style.transform = `translate(${x}vw, ${y}vh)`;
+      }
+      blobs.forEach(b=>{
+        setTimeout(()=>moveBlob(b),100);
+        setInterval(()=>moveBlob(b),30000);
+      });
+    </script>
+  </body>
+</html>

--- a/aboutme_mobile.html
+++ b/aboutme_mobile.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0X2H6SQNQP"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);} 
+      gtag('js', new Date());
+      gtag('config', 'G-0X2H6SQNQP');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Me - Tony's Media and Automation</title>
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+    <link rel="stylesheet" href="style-mobile.css" />
+  </head>
+  <body>
+    <header class="main-nav">
+      <div class="nav-dropdown">
+        <a href="#" class="nav-btn">Offers</a>
+        <div class="dropdown-content">
+          <a href="taudiomagic.html">Audio Magic</a>
+          <a href="https://tonys.lovable.app">Automation</a>
+          <a href="aivideooffer.htm">AI Video Offer</a>
+        </div>
+      </div>
+      <a href="portfolio_mobile.html" class="nav-btn">Portfolio</a>
+      <a href="aboutme_mobile.html" class="nav-btn">About Me</a>
+      <a href="index_mobile.html" class="nav-btn home-link">Home</a>
+    </header>
+    <div class="blob-bg">
+      <div class="blob"></div>
+      <div class="blob"></div>
+      <div class="blob"></div>
+    </div>
+    <header>
+      <h1>About Me</h1>
+    </header>
+    <div class="card">
+      <div class="card-content">
+        <h3><strong>Who I am?:</strong></h3>
+        I’m a media producer (20+ years) and creative automator (a little less) who blends pro-level audio,
+        visuals, practical automation and AI workflow enhancment. I help creators, startups,
+        and small teams ship more, get better outcome, and publish faster.<br />
+      </div>
+    </div>
+    <div class="legal-info">
+      <p>אנטון זצ'וסוב</p>
+      <p>בני בנימין 3 דירה 28</p>
+      <p>נתניה, 4201959</p>
+      <p>contentmage@tonysautomedia.com</p>
+    </div>
+    <div class="social-links">
+      <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+      <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+      <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+      <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+      <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+      <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
+    </div>
+    <div class="cta-buttons">
+      <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="Email">
+        <i class="fa-solid fa-envelope"></i> Write me an email
+      </a>
+      <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="WhatsApp">
+        <i class="fa-brands fa-whatsapp"></i> Write me on WhatsApp
+      </a>
+    </div>
+    <script src="nav.js"></script>
+    <script>
+      const ctaButtons = document.querySelectorAll('.cta-buttons .retro-button');
+      function pulseButtons(){
+        ctaButtons.forEach(btn=>btn.classList.add('pulse'));
+        setTimeout(()=>{ctaButtons.forEach(btn=>btn.classList.remove('pulse'));},10000);
+      }
+      pulseButtons();
+      setInterval(pulseButtons,60000);
+    </script>
+    <script>
+      const blobs = document.querySelectorAll('.blob');
+      function moveBlob(b){
+        const x = Math.random()*100-50;
+        const y = Math.random()*100-50;
+        b.style.transform = `translate(${x}vw, ${y}vh)`;
+      }
+      blobs.forEach(b=>{
+        setTimeout(()=>moveBlob(b),100);
+        setInterval(()=>moveBlob(b),30000);
+      });
+    </script>
+  </body>
+</html>

--- a/aivideooffer.htm
+++ b/aivideooffer.htm
@@ -66,9 +66,16 @@
   </head>
   <body>
     <header class="main-nav">
-      <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-      <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+      <div class="nav-dropdown">
+        <a href="#" class="nav-btn">Offers</a>
+        <div class="dropdown-content">
+          <a href="taudiomagic.html">Audio Magic</a>
+          <a href="https://tonys.lovable.app">Automation</a>
+          <a href="aivideooffer.htm">AI Video Offer</a>
+        </div>
+      </div>
       <a href="portfolio.html" class="nav-btn">Portfolio</a>
+      <a href="aboutme.html" class="nav-btn">About Me</a>
       <a href="index.html" class="nav-btn home-link">Home</a>
     </header>
     <div class="blob-bg">
@@ -174,14 +181,17 @@
       ></a>
     </div>
     <footer>
-      <p>© 2025 Tony's Automation and Media</p>
-      <div class="contact-info">
-        <p>אנטון זצ'וסוב</p>
-        <p>בני בנימין 3 דירה 28</p>
-        <p>נתניה, 4201959</p>
-        <p>contentmage@tonysautomedia.com</p>
+      <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
       </div>
     </footer>
+    <script src="nav.js"></script>
     <script>
       const ctaButtons = document.querySelectorAll(
         ".cta-buttons .retro-button"

--- a/index.html
+++ b/index.html
@@ -31,9 +31,16 @@
   </head>
   <body>
     <header class="main-nav">
-      <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-      <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+      <div class="nav-dropdown">
+        <a href="#" class="nav-btn">Offers</a>
+        <div class="dropdown-content">
+          <a href="taudiomagic.html">Audio Magic</a>
+          <a href="https://tonys.lovable.app">Automation</a>
+          <a href="aivideooffer.htm">AI Video Offer</a>
+        </div>
+      </div>
       <a href="portfolio.html" class="nav-btn">Portfolio</a>
+      <a href="aboutme.html" class="nav-btn">About Me</a>
       <a href="index.html" class="nav-btn home-link">Home</a>
     </header>
     <!-- Animated Background -->
@@ -99,14 +106,6 @@
       </div>
         </div>
     </div>
-    <div class="card">
-      <div class="card-content">
-        <h3><strong>Who I am?:</strong></h3>
-        I’m a media producer (20+ years) and creative automator (a little less) who blends pro-level audio,
-        visuals, practical automation and AI workflow enhancment. I help creators, startups,
-        and small teams ship more, get better outcome, and publish faster.<br />
-      </div>
-    </div>
     <div class="cta-buttons">
       <a
         href="aivideooffer.htm#contact-form"
@@ -126,15 +125,18 @@
 
 
     <footer>
-      <p>© 2025 Tony's Automation and Media</p>
-      <div class="contact-info">
-        <p>אנטון זצ'וסוב</p>
-        <p>בני בנימין 3 דירה 28</p>
-        <p>נתניה, 4201959</p>
-        <p>contentmage@tonysautomedia.com</p>
+      <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
       </div>
     </footer>
 
+    <script src="nav.js"></script>
     <script>
       const ctaButtons = document.querySelectorAll(
         ".cta-buttons .retro-button",

--- a/index_mobile.html
+++ b/index_mobile.html
@@ -18,9 +18,16 @@
   </head>
   <body>
     <header class="main-nav">
-      <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-      <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+      <div class="nav-dropdown">
+        <a href="#" class="nav-btn">Offers</a>
+        <div class="dropdown-content">
+          <a href="taudiomagic.html">Audio Magic</a>
+          <a href="https://tonys.lovable.app">Automation</a>
+          <a href="aivideooffer.htm">AI Video Offer</a>
+        </div>
+      </div>
       <a href="portfolio_mobile.html" class="nav-btn">Portfolio</a>
+      <a href="aboutme_mobile.html" class="nav-btn">About Me</a>
       <a href="index_mobile.html" class="nav-btn home-link">Home</a>
     </header>
     <div class="blob-bg">
@@ -82,14 +89,6 @@
       </div>
       </div>
     </div>
-    <div class="card">
-      <div class="card-content">
-        <h3><strong>Who I am?:</strong></h3>
-        I’m a media producer (20+ years) and creative automator (a little less) who blends pro-level audio,
-        visuals, practical automation and AI workflow enhancment. I help creators, startups,
-        and small teams ship more, get better outcome, and publish faster.<br />
-      </div>
-    </div>
     <div class="cta-buttons">
       <a href="aivideooffer.htm#contact-form" class="retro-button" aria-label="Email">
         <i class="fa-solid fa-envelope"></i> Write me an email
@@ -98,6 +97,18 @@
         <i class="fa-brands fa-whatsapp"></i> Write me on WhatsApp
       </a>
     </div>
+    <footer>
+      <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
+      </div>
+    </footer>
+    <script src="nav.js"></script>
     <script>
       const ctaButtons = document.querySelectorAll('.cta-buttons .retro-button');
       function pulseButtons(){

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.nav-dropdown .nav-btn').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      const dropdown = btn.parentElement;
+      dropdown.classList.toggle('open');
+    });
+  });
+
+  document.addEventListener('click', e => {
+    document.querySelectorAll('.nav-dropdown').forEach(dd => {
+      if (!dd.contains(e.target)) {
+        dd.classList.remove('open');
+      }
+    });
+  });
+});

--- a/portfolio.html
+++ b/portfolio.html
@@ -30,9 +30,16 @@
   </head>
   <body class="portfolio-page">
     <header class="main-nav">
-      <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-      <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+      <div class="nav-dropdown">
+        <a href="#" class="nav-btn">Offers</a>
+        <div class="dropdown-content">
+          <a href="taudiomagic.html">Audio Magic</a>
+          <a href="https://tonys.lovable.app">Automation</a>
+          <a href="aivideooffer.htm">AI Video Offer</a>
+        </div>
+      </div>
       <a href="portfolio.html" class="nav-btn">Portfolio</a>
+      <a href="aboutme.html" class="nav-btn">About Me</a>
       <a href="index.html" class="nav-btn home-link">Home</a>
     </header>
 
@@ -162,15 +169,18 @@
     </div>
 
     <footer>
-      <p>© 2025 Tony's Automation and Media</p>
-      <div class="contact-info">
-        <p>אנטון זצ'וסוב</p>
-        <p>בני בנימין 3 דירה 28</p>
-        <p>נתניה, 4201959</p>
-        <p>contentmage@tonysautomedia.com</p>
+      <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
       </div>
     </footer>
 
+    <script src="nav.js"></script>
     <script>
       const ctaButtons = document.querySelectorAll(
         ".cta-buttons .retro-button",

--- a/portfolio_mobile.html
+++ b/portfolio_mobile.html
@@ -18,9 +18,16 @@
   </head>
   <body class="portfolio-page">
     <header class="main-nav">
-      <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-      <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+      <div class="nav-dropdown">
+        <a href="#" class="nav-btn">Offers</a>
+        <div class="dropdown-content">
+          <a href="taudiomagic.html">Audio Magic</a>
+          <a href="https://tonys.lovable.app">Automation</a>
+          <a href="aivideooffer.htm">AI Video Offer</a>
+        </div>
+      </div>
       <a href="portfolio_mobile.html" class="nav-btn">Portfolio</a>
+      <a href="aboutme_mobile.html" class="nav-btn">About Me</a>
       <a href="index_mobile.html" class="nav-btn home-link">Home</a>
     </header>
     <div class="blob-bg">
@@ -108,6 +115,18 @@
         <i class="fa-brands fa-whatsapp"></i> Write me on WhatsApp
       </a>
     </div>
+    <footer>
+      <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
+      </div>
+    </footer>
+    <script src="nav.js"></script>
     <script>
       const ctaButtons = document.querySelectorAll('.cta-buttons .retro-button');
       function pulseButtons(){

--- a/privacy.html
+++ b/privacy.html
@@ -17,9 +17,16 @@
 </head>
 <body>
   <header class="main-nav">
-    <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-    <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+    <div class="nav-dropdown">
+      <a href="#" class="nav-btn">Offers</a>
+      <div class="dropdown-content">
+        <a href="taudiomagic.html">Audio Magic</a>
+        <a href="https://tonys.lovable.app">Automation</a>
+        <a href="aivideooffer.htm">AI Video Offer</a>
+      </div>
+    </div>
     <a href="portfolio.html" class="nav-btn">Portfolio</a>
+    <a href="aboutme.html" class="nav-btn">About Me</a>
     <a href="index.html" class="nav-btn home-link">Home</a>
   </header>
   <main class="wrap">
@@ -141,13 +148,16 @@
     <p class="small muted">Этот документ предназначен для общего информирования и не является юридической консультацией. Проверьте применимость к вашей деятельности и обновите реквизиты.</p>
   </main>
       <footer>
-        <p>© 2025 Tony's Automation and Media</p>
-      <div class="contact-info">
-        <p>אנטון זצ'וסוב</p>
-        <p>בני בנימין 3 דירה 28</p>
-        <p>נתניה, 4201959</p>
-        <p>contentmage@tonysautomedia.com</p>
+        <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
       </div>
     </footer>
+    <script src="nav.js"></script>
   </body>
   </html>

--- a/privacy_en.html
+++ b/privacy_en.html
@@ -17,9 +17,16 @@
 </head>
 <body>
   <header class="main-nav">
-    <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-    <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+    <div class="nav-dropdown">
+      <a href="#" class="nav-btn">Offers</a>
+      <div class="dropdown-content">
+        <a href="taudiomagic.html">Audio Magic</a>
+        <a href="https://tonys.lovable.app">Automation</a>
+        <a href="aivideooffer.htm">AI Video Offer</a>
+      </div>
+    </div>
     <a href="portfolio.html" class="nav-btn">Portfolio</a>
+    <a href="aboutme.html" class="nav-btn">About Me</a>
     <a href="index.html" class="nav-btn home-link">Home</a>
   </header>
   <main class="wrap">
@@ -141,13 +148,16 @@
     <p class="small muted">This document is for general information only and is not legal advice. Check applicability to your activities and update details as needed.</p>
   </main>
       <footer>
-        <p>© 2025 Tony's Automation and Media</p>
-      <div class="contact-info">
-        <p>אנטון זצ'וסוב</p>
-        <p>בני בנימין 3 דירה 28</p>
-        <p>נתניה, 4201959</p>
-        <p>contentmage@tonysautomedia.com</p>
+        <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
       </div>
     </footer>
+    <script src="nav.js"></script>
   </body>
 </html>

--- a/privacy_he.html
+++ b/privacy_he.html
@@ -18,9 +18,16 @@
 </head>
 <body>
   <header class="main-nav">
-    <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-    <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+    <div class="nav-dropdown">
+      <a href="#" class="nav-btn">Offers</a>
+      <div class="dropdown-content">
+        <a href="taudiomagic.html">Audio Magic</a>
+        <a href="https://tonys.lovable.app">Automation</a>
+        <a href="aivideooffer.htm">AI Video Offer</a>
+      </div>
+    </div>
     <a href="portfolio.html" class="nav-btn">Portfolio</a>
+    <a href="aboutme.html" class="nav-btn">About Me</a>
     <a href="index.html" class="nav-btn home-link">Home</a>
   </header>
   <main class="wrap">
@@ -142,13 +149,16 @@
     <p class="small muted">מסמך זה נועד למידע כללי ואינו מהווה ייעוץ משפטי. בדקו את תחולתו על פעילותכם ועדכנו פרטים לפי הצורך.</p>
   </main>
       <footer>
-        <p>© 2025 Tony's Automation and Media</p>
-      <div class="contact-info">
-        <p>אנטון זצ'וסוב</p>
-        <p>בני בנימין 3 דירה 28</p>
-        <p>נתניה, 4201959</p>
-        <p>contentmage@tonysautomedia.com</p>
+        <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
       </div>
     </footer>
+    <script src="nav.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@
   --indigo: #3b00bd;
   --deep-purple: #2b0057;
   --cyan: #00c5e1;
+  --white: #ffffff;
   --light-gray: #d0d0d8;
   --dark-gray: #333333;
 }
@@ -249,24 +250,67 @@ h6 {
 }
 
 .nav-btn {
+  background: none;
+  border: 1px solid var(--black);
+  color: var(--black);
+  text-decoration: none;
+  padding: 0.5% 1%;
+  border-radius: 0.25rem;
+}
+
+.nav-btn:hover {
+  background: var(--black);
+  color: var(--white) !important;
+}
+
+.home-link {
   background-color: var(--indigo);
   color: var(--cyan);
-  text-decoration: none;
-  padding: 1% 2%;
-  border-radius: 0.25rem;
+  border: none;
   transition:
     background-color 0.3s,
     color 0.3s;
 }
 
-.nav-btn:hover {
+.home-link:hover {
   background-color: var(--cyan);
   color: var(--black) !important;
 }
 
-.nav-btn:hover .fa-solid,
-.nav-btn:hover .fa-brands {
+.nav-dropdown {
+  position: relative;
+}
+
+.nav-dropdown .dropdown-content {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: var(--white);
+  border: 1px solid var(--black);
+  flex-direction: column;
+  z-index: 1000;
+}
+
+.nav-dropdown.open .dropdown-content {
+  display: flex;
+}
+
+.nav-dropdown .dropdown-content a {
+  padding: 0.5rem 1rem;
   color: var(--black);
+  text-decoration: none;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--black);
+}
+
+.nav-dropdown .dropdown-content a:last-child {
+  border-bottom: none;
+}
+
+.nav-dropdown .dropdown-content a:hover {
+  background: var(--black);
+  color: var(--white);
 }
 
 /* Video fallback image */
@@ -283,9 +327,7 @@ footer {
   background: linear-gradient(to top, var(--magenta), transparent);
   padding: 2%;
   color: var(--cyan);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  text-align: center;
   direction: ltr;
   position: fixed;
   bottom: 0;
@@ -294,13 +336,33 @@ footer {
   z-index: 1000;
 }
 
-footer .contact-info {
+.social-links {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.social-links a {
+  color: #ccc;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.social-links a:hover {
+  color: var(--white);
+}
+
+.legal-info {
   color: var(--cyan);
   text-align: right;
   direction: rtl;
 }
 
-footer .contact-info p {
+.legal-info p {
   margin: 0.2% 0;
   line-height: 1.2;
   color: var(--cyan);

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -30,9 +30,16 @@
   </head>
   <body>
     <header class="main-nav">
-      <a href="taudiomagic.html" class="nav-btn">Audio Magic</a>
-      <a href="https://tonys.lovable.app" class="nav-btn">Automation</a>
+      <div class="nav-dropdown">
+        <a href="#" class="nav-btn">Offers</a>
+        <div class="dropdown-content">
+          <a href="taudiomagic.html">Audio Magic</a>
+          <a href="https://tonys.lovable.app">Automation</a>
+          <a href="aivideooffer.htm">AI Video Offer</a>
+        </div>
+      </div>
       <a href="portfolio.html" class="nav-btn">Portfolio</a>
+      <a href="aboutme.html" class="nav-btn">About Me</a>
       <a href="index.html" class="nav-btn home-link">Home</a>
     </header>
     <!-- Animated Background -->
@@ -239,15 +246,18 @@
     </div>
 
     <footer>
-      <p>© 2025 Tony's Automation and Media</p>
-      <div class="contact-info">
-        <p>אנטון זצ'וסוב</p>
-        <p>בני בנימין 3 דירה 28</p>
-        <p>נתניה, 4201959</p>
-        <p>contentmage@tonysautomedia.com</p>
+      <p>© Tony's Media and Automation</p>
+      <div class="social-links">
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://linktr.ee/tonyzachesov"><i class="fa-solid fa-link"></i> Linktree</a>
+        <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>
+        <a href="https://wa.me/972534384116"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>
+        <a href="https://www.youtube.com/@TonyNeuro"><i class="fa-brands fa-youtube"></i> YouTube</a>
+        <a href="https://www.tiktok.com/@tony.neuro"><i class="fa-brands fa-tiktok"></i> TikTok</a>
       </div>
     </footer>
 
+    <script src="nav.js"></script>
     <script>
       const audioPlayer = document.getElementById("audioPlayer");
       const playPauseBtn = document.getElementById("playPauseBtn");


### PR DESCRIPTION
## Summary
- Convert navigation to text-based menu with Offers dropdown and About Me link across site
- Add About Me pages for desktop and mobile, relocating biography and legal info
- Replace footers with copyright and social links and add dropdown behavior script

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bcd8eed4832db2c0b5cfca44b36a