### PR TITLE
Fix CSS color declaration typo

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,7 +48,7 @@ body {
 .faq,
 .wrap {
   background-color: var(--black);
-  color: inherit;);
+  color: inherit;
 }
 /* Card layout */
 


### PR DESCRIPTION
## Summary
- remove an extra closing parenthesis from the `color: inherit` declaration in `style.css`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8f19f1fc4832da7587c012e1a64a8