### PR TITLE
Adjust mobile CTA button media queries

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,7 +140,7 @@ body {
   }
 }
 
-@media (pointer: coarse) {
+@media (max-width: 768px) {
   h1,
   h2,
   h3,
@@ -170,9 +170,13 @@ body {
     transform: translateX(-50%);
     flex-direction: row;
   }
+  .cta-buttons .retro-button {
+    width: 10vmin;
+    height: 10vmin;
+  }
 }
 
-@media (pointer: coarse) and (orientation: portrait) {
+@media (max-width: 768px) and (orientation: portrait) {
   .cards-row {
     flex-direction: column;
   }
@@ -198,7 +202,7 @@ body {
   }
 }
 
-@media (pointer: coarse) and (orientation: landscape) {
+@media (max-width: 768px) and (orientation: landscape) {
   .cards-row {
     flex-direction: row;
   }


### PR DESCRIPTION
## Summary
- replace coarse pointer media queries with a max-width breakpoint for mobile layouts
- reposition the CTA button group near the bottom of the viewport on small screens
- enlarge CTA buttons within the mobile breakpoint for better tap targets

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8f197522c832d9f8e9ef81c9a0402