### PR TITLE
Fix email and WhatsApp link schemes

### DIFF
--- a/aboutme.html
+++ b/aboutme.html
@@ -69,7 +69,7 @@
     <footer>
       <div class="social-links">
             <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
-                <a href="contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
+                <a href="mailto:contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
                 <a href="https://www.imdb.com/name/nm17689799"><i class="fa-solid fa-imdb"></i> IMDb</a>
                 <a href="https://linktr.ee/tonyzachesov"><i class="fa-brands fa-linktree"></i></i> Linktree</a>
         <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>

--- a/aivideooffer.htm
+++ b/aivideooffer.htm
@@ -145,14 +145,14 @@
     </section>
     <div class="cta-buttons">
       <a
-        href="contentmage@tonysautomedia.com"
+        href="mailto:contentmage@tonysautomedia.com"
         class="retro-button"
         aria-label="Email"
       >
         <i class="fa-solid fa-envelope"></i>
       </a>
       <a
-        href="wa.me/972534384116"
+        href="https://wa.me/972534384116"
         class="retro-button"
         aria-label="WhatsApp"
       >
@@ -162,7 +162,7 @@
     <footer>
       <div class="social-links">
             <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
-                <a href="contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
+                <a href="mailto:contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
                 <a href="https://www.imdb.com/name/nm17689799"><i class="fa-solid fa-imdb"></i> IMDb</a>
                 <a href="https://linktr.ee/tonyzachesov"><i class="fa-brands fa-linktree"></i></i> Linktree</a>
         <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>

--- a/portfolio.html
+++ b/portfolio.html
@@ -226,14 +226,14 @@
 
     <div class="cta-buttons">
       <a
-        href="contentmage@tonysautomedia.com"
+        href="mailto:contentmage@tonysautomedia.com"
         class="retro-button"
         aria-label="Email"
       >
         <i class="fa-solid fa-envelope"></i>
       </a>
       <a
-        href="wa.me/972534384116"
+        href="https://wa.me/972534384116"
         class="retro-button"
         aria-label="WhatsApp"
       >
@@ -244,7 +244,7 @@
     <footer>
       <div class="social-links">
             <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
-                <a href="contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
+                <a href="mailto:contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
                 <a href="https://www.imdb.com/name/nm17689799"><i class="fa-solid fa-imdb"></i> IMDb</a>
                 <a href="https://linktr.ee/tonyzachesov"><i class="fa-brands fa-linktree"></i></i> Linktree</a>
         <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>

--- a/privacy.html
+++ b/privacy.html
@@ -156,7 +156,7 @@
     <footer>
       <div class="social-links">
             <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
-                <a href="contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
+                <a href="mailto:contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
                 <a href="https://www.imdb.com/name/nm17689799"><i class="fa-solid fa-imdb"></i> IMDb</a>
                 <a href="https://linktr.ee/tonyzachesov"><i class="fa-brands fa-linktree"></i></i> Linktree</a>
         <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>

--- a/privacy_en.html
+++ b/privacy_en.html
@@ -156,7 +156,7 @@
     <footer>
       <div class="social-links">
             <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
-                <a href="contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
+                <a href="mailto:contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
                 <a href="https://www.imdb.com/name/nm17689799"><i class="fa-solid fa-imdb"></i> IMDb</a>
                 <a href="https://linktr.ee/tonyzachesov"><i class="fa-brands fa-linktree"></i></i> Linktree</a>
         <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>

--- a/privacy_he.html
+++ b/privacy_he.html
@@ -157,7 +157,7 @@
     <footer>
       <div class="social-links">
             <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
-                <a href="contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
+                <a href="mailto:contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
                 <a href="https://www.imdb.com/name/nm17689799"><i class="fa-solid fa-imdb"></i> IMDb</a>
                 <a href="https://linktr.ee/tonyzachesov"><i class="fa-brands fa-linktree"></i></i> Linktree</a>
         <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -202,7 +202,7 @@
     <footer>
       <div class="social-links">
             <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
-                <a href="contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
+                <a href="mailto:contentmage@tonysautomedia.com"><i class="fa-solid fa-envelope"></i> Email</a>
                 <a href="https://www.imdb.com/name/nm17689799"><i class="fa-solid fa-imdb"></i> IMDb</a>
                 <a href="https://linktr.ee/tonyzachesov"><i class="fa-brands fa-linktree"></i></i> Linktree</a>
         <a href="https://www.facebook.com/necrozzmsk"><i class="fa-brands fa-facebook"></i> Facebook</a>


### PR DESCRIPTION
## Summary
- update email contact links to use the proper `mailto:` scheme across pages
- ensure WhatsApp call-to-action links consistently use `https://wa.me`

## Testing
- not run (static HTML updates)


------
https://chatgpt.com/codex/tasks/task_e_68c8f1e487e4832daaf89ff39bf72a4c