### PR TITLE
Move CTA buttons to bottom center and enlarge

### DIFF
--- a/style.css
+++ b/style.css
@@ -163,16 +163,16 @@ body {
     display: none;
   }
   .cta-buttons {
-    top: auto;
     bottom: 2vh;
     left: 50%;
     right: auto;
     transform: translateX(-50%);
-    flex-direction: row;
+    gap: 1.25rem;
   }
   .cta-buttons .retro-button {
-    width: 10vmin;
-    height: 10vmin;
+    width: clamp(4rem, 18vmin, 5.75rem);
+    height: clamp(4rem, 18vmin, 5.75rem);
+    font-size: clamp(1.5rem, 4vmin, 2rem);
   }
 }
 
@@ -641,25 +641,25 @@ footer {
 /* Call to action */
 .cta-buttons {
   position: fixed;
-  top: 50%;
-  right: 2%;
-  transform: translateY(-50%);
+  bottom: 3vh;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
-  flex-direction: column;
-  gap: 1.5%;
+  flex-direction: row;
+  gap: 1.5rem;
   margin: 0;
   z-index: 1000;
 }
 
 .cta-buttons .retro-button {
-  width: 5vmin;
-  height: 5vmin;
+  width: clamp(3.5rem, 8vmin, 4.75rem);
+  height: clamp(3.5rem, 8vmin, 4.75rem);
   padding: 0;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.125rem;
+  font-size: clamp(1.25rem, 3vmin, 1.75rem);
   opacity: 0.6;
   transition:
     opacity 0.3s,


### PR DESCRIPTION
## Summary
- reposition the floating call-to-action buttons to the centered bottom of the viewport for consistent placement
- enlarge the email and WhatsApp buttons and adjust their typography to improve visibility across screen sizes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caaa9c69d4832dadcce28b3637e9da