### PR TITLE
Refine mobile navigation layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -162,6 +162,15 @@ body {
   footer {
     display: none;
   }
+  .main-nav {
+    padding: 0.65rem 1.25rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .nav-btn {
+    font-size: 1rem;
+    padding: 0.4rem 0.75rem;
+  }
   .cta-buttons {
     top: auto;
     bottom: 2vh;
@@ -202,6 +211,24 @@ body {
   .portfolio-grid .card {
     margin-bottom: 1rem;
   }
+  .main-nav {
+    row-gap: 0.75rem;
+    column-gap: 0.75rem;
+    flex-direction: row;
+  }
+  .nav-left,
+  .nav-right {
+    flex: 1 1 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .nav-right {
+    order: -1;
+  }
+  .nav-btn {
+    flex: 1 1 45%;
+  }
 }
 
 @media (max-width: 768px) and (orientation: landscape) {
@@ -215,6 +242,21 @@ body {
     text-align: left;
     width: auto;
     margin-bottom: 0;
+  }
+  .main-nav {
+    flex-wrap: nowrap;
+    gap: 0.75rem;
+  }
+  .nav-left,
+  .nav-right {
+    flex: 1 1 auto;
+    gap: 0.75rem;
+  }
+  .nav-right {
+    order: 0;
+  }
+  .nav-btn {
+    flex: 1 1 clamp(6rem, 22vw, 10rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten the mobile navigation padding and button sizing for small screens
- restructure portrait navigation wrapping to keep controls visible and ordered with Home first
- adjust landscape navigation flex sizing so buttons scale within horizontal space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc00097cd8832dbeb6935b516ba2d9