### PR TITLE
Fix mobile hamburger menu behavior on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -174,7 +174,8 @@ body {
     flex-direction: column;
     gap: 0.35rem;
     align-self: flex-end;
-    margin-left: 0;
+    margin-left: auto;
+    width: auto;
   }
   .main-nav.nav-open .nav-toggle-bar:nth-of-type(1) {
     transform: translateY(0.5rem) rotate(45deg);
@@ -185,7 +186,7 @@ body {
   .main-nav.nav-open .nav-toggle-bar:nth-of-type(3) {
     transform: translateY(-0.5rem) rotate(-45deg);
   }
-  .nav-menu {
+  .main-nav .nav-menu {
     display: none;
     flex-direction: column;
     gap: 0.5rem;


### PR DESCRIPTION
## Summary
- ensure the mobile hamburger toggle stays on the right side of the navigation bar
- hide the navigation links on mobile until the menu is opened

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc1145f18c832d97de70f9b7dfe1ff