### PR TITLE
Fix CTA button positioning on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -162,20 +162,6 @@ body {
   footer {
     display: none;
   }
-  .cta-buttons {
-    top: auto;
-    bottom: 2vh;
-    right: auto;
-    left: 50%;
-    transform: translateX(-50%);
-    flex-direction: row;
-    gap: 1.25rem;
-  }
-  .cta-buttons .retro-button {
-    width: clamp(4rem, 18vmin, 5.75rem);
-    height: clamp(4rem, 18vmin, 5.75rem);
-    font-size: clamp(1.5rem, 4vmin, 2rem);
-  }
 }
 
 @media (max-width: 768px) and (orientation: portrait) {
@@ -820,6 +806,25 @@ footer {
 
 .cta-buttons .retro-button.pulse {
   animation: button-pulse 10s ease-in-out;
+}
+
+@media (max-width: 768px) {
+  .cta-buttons {
+    top: auto;
+    bottom: 2vh;
+    right: auto;
+    left: 50%;
+    transform: translate(-50%, 0);
+    flex-direction: row;
+    justify-content: center;
+    gap: 1.25rem;
+  }
+
+  .cta-buttons .retro-button {
+    width: clamp(4rem, 18vmin, 5.75rem);
+    height: clamp(4rem, 18vmin, 5.75rem);
+    font-size: clamp(1.5rem, 4vmin, 2rem);
+  }
 }
 
 @keyframes button-pulse {


### PR DESCRIPTION
## Summary
- ensure the CTA button mobile styles override the desktop defaults by relocating the responsive CSS block
- align the CTA button group along the bottom center of mobile screens with consistent sizing

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc15f601f8832db47deb87f757126d