### PR TITLE
Add localized voice cleanup offer pages

### DIFF
--- a/he/voicecleanupoffer.html
+++ b/he/voicecleanupoffer.html
@@ -1,0 +1,323 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-0X2H6SQNQP"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-0X2H6SQNQP");
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>הצעת ניקוי קול</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body class="voice-cleanup-page">
+    <header class="main-nav">
+      <button
+        class="nav-toggle"
+        aria-expanded="false"
+        aria-controls="primary-navigation"
+        aria-label="פתיחת תפריט"
+      >
+        <span class="sr-only">תפריט</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="nav-menu">
+        <div class="nav-left">
+          <div class="nav-dropdown">
+            <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
+              >שירותים&nbsp;<span class="arrow">&gt;</span></a
+            >
+            <div class="dropdown-content">
+              <a href="taudiomagic.html">פוסט אודיו</a>
+              <a href="https://tonys.lovabel.app">אוטומציה</a>
+              <a href="aivideooffer.html">וידאו AI</a>
+              <a
+                href="voicecleanupoffer.html"
+                aria-current="page"
+                data-offer="voice-cleanup"
+                >ניקוי קול</a
+              >
+            </div>
+          </div>
+          <a href="portfolio.html" class="nav-btn">תיק עבודות</a>
+          <a href="aboutme.html" class="nav-btn">עליי</a>
+        </div>
+        <div class="nav-right">
+          <a href="index.html" class="nav-btn">בית</a>
+          <div class="nav-lang">
+            <a href="../voicecleanupoffer.html" class="nav-btn" lang="en">en</a>
+            <a href="../ru/voicecleanupoffer.html" class="nav-btn" lang="ru">ru</a>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <main class="page-content">
+      <div class="blob-bg">
+        <div class="blob"></div>
+        <div class="blob"></div>
+        <div class="blob"></div>
+      </div>
+
+      <header>
+        <h1>הצעת ניקוי קול</h1>
+        <div class="tagline">להחזיר את הצלילות, לשמור על הנשמה של הקול שלך</div>
+      </header>
+
+      <section class="voice-cleanup container">
+        <div class="voice-cleanup-grid">
+          <div class="offer-card audio-card">
+            <h2 class="section-title">תשמעו את ההבדל</h2>
+            <p>
+              עברו בין ההקלטה המקורית לניקוי בעזרת ה-AI שלי כדי לשמוע כמה
+              רעש וחדות אפשר להסיר ועדיין לשמור על הביצוע האמיתי.
+            </p>
+            <div class="audio-player-container">
+              <div class="track-buttons">
+                <button class="track-btn active" data-track="ai">
+                  <span class="track-label">ניקוי AI</span>
+                </button>
+                <button class="track-btn" data-track="original">
+                  <span class="track-label">מקורית</span>
+                </button>
+              </div>
+              <div class="audio-player">
+                <div class="player-info">
+                  <span class="current-track">ניקוי AI</span>
+                  <span class="track-time">0:00 / 0:00</span>
+                </div>
+                <div class="player-controls">
+                  <button class="play-pause-btn" id="voiceCleanupPlayPause">
+                    <span class="play-icon">▶️</span>
+                  </button>
+                  <div class="progress-container">
+                    <div class="progress-bar">
+                      <div class="progress-fill"></div>
+                    </div>
+                  </div>
+                  <div class="volume-container">
+                    <span class="volume-icon">🔊</span>
+                    <input
+                      type="range"
+                      class="volume-slider"
+                      min="0"
+                      max="100"
+                      value="70"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <audio id="voiceCleanupPlayer" preload="metadata">
+              <source
+                src="../Just%20AI.mp3"
+                type="audio/mpeg"
+                data-track="ai"
+              />
+              <source
+                src="../Original.mp3"
+                type="audio/mpeg"
+                data-track="original"
+              />
+              הדפדפן שלך לא תומך באלמנט האודיו.
+            </audio>
+          </div>
+
+          <div class="offer-card form-card">
+            <h2 class="section-title">התחילו את הניקוי</h2>
+            <p>
+              ספרו לי על הפרויקט ואחזור אליכם עם תוכנית מותאמת למסירת רצועות
+              קול נקיות.
+            </p>
+            <div class="form-embed">
+              <iframe
+                src="https://docs.google.com/forms/d/e/1FAIpQLSdG85R-DSKVQE_RiTLUJX-PM2VLAiGrMGMxoJI4h1LKWqA0iA/viewform?embedded=true"
+                width="640"
+                height="554"
+                frameborder="0"
+                marginheight="0"
+                marginwidth="0"
+                >Loading…</iframe
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <div class="cta-buttons">
+      <a
+        href="mailto:contentmage@tonysautomedia.com"
+        class="retro-button"
+        aria-label="אימייל"
+      >
+        <i class="fa-solid fa-envelope"></i>
+      </a>
+      <a
+        href="https://wa.me/972534384116"
+        class="retro-button"
+        aria-label="וואטסאפ"
+      >
+        <i class="fa-brands fa-whatsapp"></i>
+      </a>
+    </div>
+    <br /><br /><br />
+    <footer>
+      <div class="social-links">
+        <a href="index.html"
+          ><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a
+        >
+        <a href="mailto:contentmage@tonysautomedia.com"
+          ><i class="fa-solid fa-envelope"></i> Email</a
+        >
+        <a href="https://www.imdb.com/name/nm17689799"
+          ><i class="fa fa-imdb"></i> IMDb</a
+        >
+        <a href="https://linktr.ee/tonyzachesov"
+          ><i class="fa-brands fa-linktree"></i></i> Linktree</a
+        >
+        <a href="https://www.facebook.com/necrozzmsk"
+          ><i class="fa-brands fa-facebook"></i> Facebook</a
+        >
+        <a href="https://wa.me/972534384116"
+          ><i class="fa-brands fa-whatsapp"></i> WhatsApp</a
+        >
+        <a href="https://www.youtube.com/@TonyNeuro"
+          ><i class="fa-brands fa-youtube"></i> YouTube</a
+        >
+        <a href="https://www.tiktok.com/@tony.neuro"
+          ><i class="fa-brands fa-tiktok"></i> TikTok</a
+        >
+      </div>
+    </footer>
+
+    <script src="../nav.js"></script>
+    <script>
+      const voiceCleanupPlayer = document.getElementById("voiceCleanupPlayer");
+      const voicePlayPauseBtn = document.getElementById("voiceCleanupPlayPause");
+      const voiceTrackButtons = document.querySelectorAll(
+        ".voice-cleanup-page .track-btn",
+      );
+      const voiceTrackLabel = document.querySelector(
+        ".voice-cleanup-page .current-track",
+      );
+      const voiceProgressFill = document.querySelector(
+        ".voice-cleanup-page .progress-fill",
+      );
+      const voiceTrackTime = document.querySelector(
+        ".voice-cleanup-page .track-time",
+      );
+      const voiceVolumeSlider = document.querySelector(
+        ".voice-cleanup-page .volume-slider",
+      );
+
+      const voiceTracks = {
+        ai: "../Just%20AI.mp3",
+        original: "../Original.mp3",
+      };
+
+      function formatVoiceTime(sec) {
+        const m = Math.floor(sec / 60) || 0;
+        const s = Math.floor(sec % 60) || 0;
+        return `${m}:${s.toString().padStart(2, "0")}`;
+      }
+
+      function loadVoiceTrack(key, label) {
+        voiceCleanupPlayer.src = voiceTracks[key];
+        voiceCleanupPlayer.load();
+        voiceTrackLabel.textContent = label;
+        voicePlayPauseBtn.innerHTML = '<span class="play-icon">▶️</span>';
+        voiceTrackTime.textContent = `0:00 / 0:00`;
+      }
+
+      voiceTrackButtons.forEach((btn) => {
+        btn.addEventListener("click", () => {
+          voiceTrackButtons.forEach((b) => b.classList.remove("active"));
+          btn.classList.add("active");
+          loadVoiceTrack(
+            btn.dataset.track,
+            btn.querySelector(".track-label").textContent,
+          );
+          voiceCleanupPlayer.play();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
+        });
+      });
+
+      voicePlayPauseBtn.addEventListener("click", () => {
+        if (voiceCleanupPlayer.paused) {
+          voiceCleanupPlayer.play();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
+        } else {
+          voiceCleanupPlayer.pause();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">▶️</span>';
+        }
+      });
+
+      voiceCleanupPlayer.addEventListener("timeupdate", () => {
+        const progress =
+          (voiceCleanupPlayer.currentTime / voiceCleanupPlayer.duration) * 100;
+        voiceProgressFill.style.width = `${progress || 0}%`;
+        voiceTrackTime.textContent = `${formatVoiceTime(
+          voiceCleanupPlayer.currentTime,
+        )} / ${formatVoiceTime(voiceCleanupPlayer.duration)}`;
+      });
+
+      voiceCleanupPlayer.addEventListener("loadedmetadata", () => {
+        voiceTrackTime.textContent = `0:00 / ${formatVoiceTime(
+          voiceCleanupPlayer.duration,
+        )}`;
+      });
+
+      voiceVolumeSlider.addEventListener("input", () => {
+        voiceCleanupPlayer.volume = voiceVolumeSlider.value / 100;
+      });
+
+      loadVoiceTrack("ai", "ניקוי AI");
+    </script>
+    <script>
+      const ctaButtons = document.querySelectorAll(
+        ".cta-buttons .retro-button",
+      );
+      function pulseButtons() {
+        ctaButtons.forEach((btn) => btn.classList.add("pulse"));
+        setTimeout(() => {
+          ctaButtons.forEach((btn) => btn.classList.remove("pulse"));
+        }, 10000);
+      }
+      pulseButtons();
+      setInterval(pulseButtons, 60000);
+    </script>
+    <script>
+      const blobs = document.querySelectorAll(".blob");
+      function moveBlob(b) {
+        const x = Math.random() * 100 - 50;
+        const y = Math.random() * 100 - 50;
+        b.style.transform = `translate(${x}vw, ${y}vh)`;
+      }
+      blobs.forEach((b) => {
+        setTimeout(() => moveBlob(b), 100);
+        setInterval(() => moveBlob(b), 30000);
+      });
+    </script>
+  </body>
+</html>

--- a/nav.js
+++ b/nav.js
@@ -4,6 +4,34 @@ document.addEventListener('DOMContentLoaded', () => {
   const navMenu = document.querySelector('.nav-menu');
   const dropdowns = Array.from(document.querySelectorAll('.nav-dropdown'));
 
+  const language = document.documentElement.lang || 'en';
+  const voiceLinkLabels = {
+    he: 'ניקוי קול',
+    ru: 'Очистка голоса',
+  };
+  const voiceLinkText = voiceLinkLabels[language] || 'Voice Clean Up';
+  const isVoiceCleanupPage = /voicecleanupoffer\.html$/i.test(
+    window.location.pathname,
+  );
+
+  const offerMenus = document.querySelectorAll('.dropdown-content');
+  offerMenus.forEach(menu => {
+    let voiceLink = menu.querySelector('[data-offer="voice-cleanup"]');
+    if (!voiceLink) {
+      voiceLink = document.createElement('a');
+      voiceLink.href = 'voicecleanupoffer.html';
+      voiceLink.dataset.offer = 'voice-cleanup';
+      voiceLink.textContent = voiceLinkText;
+      menu.appendChild(voiceLink);
+    } else if (!voiceLink.textContent.trim()) {
+      voiceLink.textContent = voiceLinkText;
+    }
+
+    if (isVoiceCleanupPage && !voiceLink.hasAttribute('aria-current')) {
+      voiceLink.setAttribute('aria-current', 'page');
+    }
+  });
+
   const closeDropdown = dropdown => {
     dropdown.classList.remove('open');
     const trigger = dropdown.querySelector('.nav-btn');

--- a/ru/voicecleanupoffer.html
+++ b/ru/voicecleanupoffer.html
@@ -1,0 +1,324 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-0X2H6SQNQP"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-0X2H6SQNQP");
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Предложение по очистке голоса</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body class="voice-cleanup-page">
+    <header class="main-nav">
+      <button
+        class="nav-toggle"
+        aria-expanded="false"
+        aria-controls="primary-navigation"
+        aria-label="Открыть меню"
+      >
+        <span class="sr-only">Меню</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="nav-menu">
+        <div class="nav-left">
+          <div class="nav-dropdown">
+            <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
+              >Услуги&nbsp;<span class="arrow">&gt;</span></a
+            >
+            <div class="dropdown-content">
+              <a href="taudiomagic.html">Аудио постпродакшн</a>
+              <a href="https://tonys.lovabel.app">Автоматизация</a>
+              <a href="aivideooffer.html">Видеопредложение AI</a>
+              <a
+                href="voicecleanupoffer.html"
+                aria-current="page"
+                data-offer="voice-cleanup"
+                >Очистка голоса</a
+              >
+            </div>
+          </div>
+          <a href="portfolio.html" class="nav-btn">Портфолио</a>
+          <a href="aboutme.html" class="nav-btn">Обо мне</a>
+        </div>
+        <div class="nav-right">
+          <a href="index.html" class="nav-btn">Главная</a>
+          <div class="nav-lang">
+            <a href="../voicecleanupoffer.html" class="nav-btn" lang="en">en</a>
+            <a href="../he/voicecleanupoffer.html" class="nav-btn" lang="he">he</a>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <main class="page-content">
+      <div class="blob-bg">
+        <div class="blob"></div>
+        <div class="blob"></div>
+        <div class="blob"></div>
+      </div>
+
+      <header>
+        <h1>Очистка голоса</h1>
+        <div class="tagline">Верните ясность, сохранив характер вашего голоса</div>
+      </header>
+
+      <section class="voice-cleanup container">
+        <div class="voice-cleanup-grid">
+          <div class="offer-card audio-card">
+            <h2 class="section-title">Услышьте разницу</h2>
+            <p>
+              Переключайтесь между оригинальной записью и моей очисткой с помощью
+              ИИ, чтобы услышать, сколько шума и резкости можно убрать, сохранив
+              исполнение.
+            </p>
+            <div class="audio-player-container">
+              <div class="track-buttons">
+                <button class="track-btn active" data-track="ai">
+                  <span class="track-label">AI-очистка</span>
+                </button>
+                <button class="track-btn" data-track="original">
+                  <span class="track-label">Оригинал</span>
+                </button>
+              </div>
+              <div class="audio-player">
+                <div class="player-info">
+                  <span class="current-track">AI-очистка</span>
+                  <span class="track-time">0:00 / 0:00</span>
+                </div>
+                <div class="player-controls">
+                  <button class="play-pause-btn" id="voiceCleanupPlayPause">
+                    <span class="play-icon">▶️</span>
+                  </button>
+                  <div class="progress-container">
+                    <div class="progress-bar">
+                      <div class="progress-fill"></div>
+                    </div>
+                  </div>
+                  <div class="volume-container">
+                    <span class="volume-icon">🔊</span>
+                    <input
+                      type="range"
+                      class="volume-slider"
+                      min="0"
+                      max="100"
+                      value="70"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <audio id="voiceCleanupPlayer" preload="metadata">
+              <source
+                src="../Just%20AI.mp3"
+                type="audio/mpeg"
+                data-track="ai"
+              />
+              <source
+                src="../Original.mp3"
+                type="audio/mpeg"
+                data-track="original"
+              />
+              Ваш браузер не поддерживает элемент audio.
+            </audio>
+          </div>
+
+          <div class="offer-card form-card">
+            <h2 class="section-title">Начните очистку</h2>
+            <p>
+              Расскажите о проекте, и я свяжусь с вами с индивидуальным планом
+              по созданию безупречных голосовых дорожек.
+            </p>
+            <div class="form-embed">
+              <iframe
+                src="https://docs.google.com/forms/d/e/1FAIpQLSdG85R-DSKVQE_RiTLUJX-PM2VLAiGrMGMxoJI4h1LKWqA0iA/viewform?embedded=true"
+                width="640"
+                height="554"
+                frameborder="0"
+                marginheight="0"
+                marginwidth="0"
+                >Loading…</iframe
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <div class="cta-buttons">
+      <a
+        href="mailto:contentmage@tonysautomedia.com"
+        class="retro-button"
+        aria-label="Email"
+      >
+        <i class="fa-solid fa-envelope"></i>
+      </a>
+      <a
+        href="https://wa.me/972534384116"
+        class="retro-button"
+        aria-label="WhatsApp"
+      >
+        <i class="fa-brands fa-whatsapp"></i>
+      </a>
+    </div>
+    <br /><br /><br />
+    <footer>
+      <div class="social-links">
+        <a href="index.html"
+          ><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a
+        >
+        <a href="mailto:contentmage@tonysautomedia.com"
+          ><i class="fa-solid fa-envelope"></i> Email</a
+        >
+        <a href="https://www.imdb.com/name/nm17689799"
+          ><i class="fa fa-imdb"></i> IMDb</a
+        >
+        <a href="https://linktr.ee/tonyzachesov"
+          ><i class="fa-brands fa-linktree"></i></i> Linktree</a
+        >
+        <a href="https://www.facebook.com/necrozzmsk"
+          ><i class="fa-brands fa-facebook"></i> Facebook</a
+        >
+        <a href="https://wa.me/972534384116"
+          ><i class="fa-brands fa-whatsapp"></i> WhatsApp</a
+        >
+        <a href="https://www.youtube.com/@TonyNeuro"
+          ><i class="fa-brands fa-youtube"></i> YouTube</a
+        >
+        <a href="https://www.tiktok.com/@tony.neuro"
+          ><i class="fa-brands fa-tiktok"></i> TikTok</a
+        >
+      </div>
+    </footer>
+
+    <script src="../nav.js"></script>
+    <script>
+      const voiceCleanupPlayer = document.getElementById("voiceCleanupPlayer");
+      const voicePlayPauseBtn = document.getElementById("voiceCleanupPlayPause");
+      const voiceTrackButtons = document.querySelectorAll(
+        ".voice-cleanup-page .track-btn",
+      );
+      const voiceTrackLabel = document.querySelector(
+        ".voice-cleanup-page .current-track",
+      );
+      const voiceProgressFill = document.querySelector(
+        ".voice-cleanup-page .progress-fill",
+      );
+      const voiceTrackTime = document.querySelector(
+        ".voice-cleanup-page .track-time",
+      );
+      const voiceVolumeSlider = document.querySelector(
+        ".voice-cleanup-page .volume-slider",
+      );
+
+      const voiceTracks = {
+        ai: "../Just%20AI.mp3",
+        original: "../Original.mp3",
+      };
+
+      function formatVoiceTime(sec) {
+        const m = Math.floor(sec / 60) || 0;
+        const s = Math.floor(sec % 60) || 0;
+        return `${m}:${s.toString().padStart(2, "0")}`;
+      }
+
+      function loadVoiceTrack(key, label) {
+        voiceCleanupPlayer.src = voiceTracks[key];
+        voiceCleanupPlayer.load();
+        voiceTrackLabel.textContent = label;
+        voicePlayPauseBtn.innerHTML = '<span class="play-icon">▶️</span>';
+        voiceTrackTime.textContent = `0:00 / 0:00`;
+      }
+
+      voiceTrackButtons.forEach((btn) => {
+        btn.addEventListener("click", () => {
+          voiceTrackButtons.forEach((b) => b.classList.remove("active"));
+          btn.classList.add("active");
+          loadVoiceTrack(
+            btn.dataset.track,
+            btn.querySelector(".track-label").textContent,
+          );
+          voiceCleanupPlayer.play();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
+        });
+      });
+
+      voicePlayPauseBtn.addEventListener("click", () => {
+        if (voiceCleanupPlayer.paused) {
+          voiceCleanupPlayer.play();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
+        } else {
+          voiceCleanupPlayer.pause();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">▶️</span>';
+        }
+      });
+
+      voiceCleanupPlayer.addEventListener("timeupdate", () => {
+        const progress =
+          (voiceCleanupPlayer.currentTime / voiceCleanupPlayer.duration) * 100;
+        voiceProgressFill.style.width = `${progress || 0}%`;
+        voiceTrackTime.textContent = `${formatVoiceTime(
+          voiceCleanupPlayer.currentTime,
+        )} / ${formatVoiceTime(voiceCleanupPlayer.duration)}`;
+      });
+
+      voiceCleanupPlayer.addEventListener("loadedmetadata", () => {
+        voiceTrackTime.textContent = `0:00 / ${formatVoiceTime(
+          voiceCleanupPlayer.duration,
+        )}`;
+      });
+
+      voiceVolumeSlider.addEventListener("input", () => {
+        voiceCleanupPlayer.volume = voiceVolumeSlider.value / 100;
+      });
+
+      loadVoiceTrack("ai", "AI-очистка");
+    </script>
+    <script>
+      const ctaButtons = document.querySelectorAll(
+        ".cta-buttons .retro-button",
+      );
+      function pulseButtons() {
+        ctaButtons.forEach((btn) => btn.classList.add("pulse"));
+        setTimeout(() => {
+          ctaButtons.forEach((btn) => btn.classList.remove("pulse"));
+        }, 10000);
+      }
+      pulseButtons();
+      setInterval(pulseButtons, 60000);
+    </script>
+    <script>
+      const blobs = document.querySelectorAll(".blob");
+      function moveBlob(b) {
+        const x = Math.random() * 100 - 50;
+        const y = Math.random() * 100 - 50;
+        b.style.transform = `translate(${x}vw, ${y}vh)`;
+      }
+      blobs.forEach((b) => {
+        setTimeout(() => moveBlob(b), 100);
+        setInterval(() => moveBlob(b), 30000);
+      });
+    </script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1110,3 +1110,41 @@ footer {
     border-radius: 60% 40% 30% 70% / 60% 50% 40% 30%;
   }
 }
+
+.voice-cleanup-grid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.voice-cleanup-grid .offer-card {
+  width: min(100%, 40rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.voice-cleanup-page .section-title {
+  margin-bottom: 0;
+}
+
+.voice-cleanup-page .audio-player-container,
+.voice-cleanup-page .audio-player {
+  width: 100%;
+}
+
+.voice-cleanup-page .form-embed iframe {
+  width: 100%;
+  min-height: 35rem;
+  border: none;
+  background: var(--black);
+  border-radius: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .voice-cleanup-page .form-embed iframe {
+    min-height: 28rem;
+  }
+}

--- a/voicecleanupoffer.html
+++ b/voicecleanupoffer.html
@@ -1,0 +1,320 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-0X2H6SQNQP"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-0X2H6SQNQP");
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Voice Clean Up Offer</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body class="voice-cleanup-page">
+    <header class="main-nav">
+      <button
+        class="nav-toggle"
+        aria-expanded="false"
+        aria-controls="primary-navigation"
+        aria-label="Toggle navigation"
+      >
+        <span class="sr-only">Menu</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="nav-menu">
+        <div class="nav-left">
+          <div class="nav-dropdown">
+            <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
+              >Offers&nbsp;<span class="arrow">&gt;</span></a
+            >
+            <div class="dropdown-content">
+              <a href="taudiomagic.html">Audio Post-</a>
+              <a href="https://tonys.lovabel.app">Automation</a>
+              <a href="aivideooffer.htm">AI Video Offer</a>
+              <a
+                href="voicecleanupoffer.html"
+                aria-current="page"
+                data-offer="voice-cleanup"
+                >Voice Clean Up</a
+              >
+            </div>
+          </div>
+          <a href="portfolio.html" class="nav-btn">Portfolio</a>
+          <a href="aboutme.html" class="nav-btn">About Me</a>
+        </div>
+        <div class="nav-right">
+          <a href="index.html" class="nav-btn">Home</a>
+          <div class="nav-lang">
+            <a href="he/voicecleanupoffer.html" class="nav-btn" lang="he">he</a>
+            <a href="ru/voicecleanupoffer.html" class="nav-btn" lang="ru">ru</a>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <main class="page-content">
+      <div class="blob-bg">
+        <div class="blob"></div>
+        <div class="blob"></div>
+        <div class="blob"></div>
+      </div>
+
+      <header>
+        <h1>Voice Clean Up Offer</h1>
+        <div class="tagline">Restore clarity, keep the soul of your voice</div>
+      </header>
+
+      <section class="voice-cleanup container">
+        <div class="voice-cleanup-grid">
+          <div class="offer-card audio-card">
+            <h2 class="section-title">Hear the Difference</h2>
+            <p>
+              Switch between the original recording and my AI-assisted cleanup to
+              hear how much noise and harshness can be removed while keeping the
+              performance intact.
+            </p>
+            <div class="audio-player-container">
+              <div class="track-buttons">
+                <button class="track-btn active" data-track="ai">
+                  <span class="track-label">AI Clean</span>
+                </button>
+                <button class="track-btn" data-track="original">
+                  <span class="track-label">Original</span>
+                </button>
+              </div>
+              <div class="audio-player">
+                <div class="player-info">
+                  <span class="current-track">AI Clean</span>
+                  <span class="track-time">0:00 / 0:00</span>
+                </div>
+                <div class="player-controls">
+                  <button class="play-pause-btn" id="voiceCleanupPlayPause">
+                    <span class="play-icon">▶️</span>
+                  </button>
+                  <div class="progress-container">
+                    <div class="progress-bar">
+                      <div class="progress-fill"></div>
+                    </div>
+                  </div>
+                  <div class="volume-container">
+                    <span class="volume-icon">🔊</span>
+                    <input
+                      type="range"
+                      class="volume-slider"
+                      min="0"
+                      max="100"
+                      value="70"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <audio id="voiceCleanupPlayer" preload="metadata">
+              <source
+                src="Just%20AI.mp3"
+                type="audio/mpeg"
+                data-track="ai"
+              />
+              <source
+                src="Original.mp3"
+                type="audio/mpeg"
+                data-track="original"
+              />
+              Your browser does not support the audio element.
+            </audio>
+          </div>
+
+          <div class="offer-card form-card">
+            <h2 class="section-title">Start Your Cleanup</h2>
+            <p>
+              Tell me about your project and I'll follow up with a tailored plan
+              for delivering pristine voice tracks.
+            </p>
+            <div class="form-embed">
+              <iframe
+                src="https://docs.google.com/forms/d/e/1FAIpQLSdG85R-DSKVQE_RiTLUJX-PM2VLAiGrMGMxoJI4h1LKWqA0iA/viewform?embedded=true"
+                width="640"
+                height="554"
+                frameborder="0"
+                marginheight="0"
+                marginwidth="0"
+                >Loading…</iframe
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <div class="cta-buttons">
+      <a
+        href="mailto:contentmage@tonysautomedia.com"
+        class="retro-button"
+        aria-label="Email"
+      >
+        <i class="fa-solid fa-envelope"></i>
+      </a>
+      <a href="https://wa.me/972534384116" class="retro-button" aria-label="WhatsApp">
+        <i class="fa-brands fa-whatsapp"></i>
+      </a>
+    </div>
+    <br /><br /><br />
+    <footer>
+      <div class="social-links">
+        <a href="index.html"
+          ><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a
+        >
+        <a href="mailto:contentmage@tonysautomedia.com"
+          ><i class="fa-solid fa-envelope"></i> Email</a
+        >
+        <a href="https://www.imdb.com/name/nm17689799"
+          ><i class="fa fa-imdb"></i> IMDb</a
+        >
+        <a href="https://linktr.ee/tonyzachesov"
+          ><i class="fa-brands fa-linktree"></i></i> Linktree</a
+        >
+        <a href="https://www.facebook.com/necrozzmsk"
+          ><i class="fa-brands fa-facebook"></i> Facebook</a
+        >
+        <a href="https://wa.me/972534384116"
+          ><i class="fa-brands fa-whatsapp"></i> WhatsApp</a
+        >
+        <a href="https://www.youtube.com/@TonyNeuro"
+          ><i class="fa-brands fa-youtube"></i> YouTube</a
+        >
+        <a href="https://www.tiktok.com/@tony.neuro"
+          ><i class="fa-brands fa-tiktok"></i> TikTok</a
+        >
+      </div>
+    </footer>
+
+    <script src="nav.js"></script>
+    <script>
+      const voiceCleanupPlayer = document.getElementById("voiceCleanupPlayer");
+      const voicePlayPauseBtn = document.getElementById("voiceCleanupPlayPause");
+      const voiceTrackButtons = document.querySelectorAll(
+        ".voice-cleanup-page .track-btn",
+      );
+      const voiceTrackLabel = document.querySelector(
+        ".voice-cleanup-page .current-track",
+      );
+      const voiceProgressFill = document.querySelector(
+        ".voice-cleanup-page .progress-fill",
+      );
+      const voiceTrackTime = document.querySelector(
+        ".voice-cleanup-page .track-time",
+      );
+      const voiceVolumeSlider = document.querySelector(
+        ".voice-cleanup-page .volume-slider",
+      );
+
+      const voiceTracks = {
+        ai: "Just%20AI.mp3",
+        original: "Original.mp3",
+      };
+
+      function formatVoiceTime(sec) {
+        const m = Math.floor(sec / 60) || 0;
+        const s = Math.floor(sec % 60) || 0;
+        return `${m}:${s.toString().padStart(2, "0")}`;
+      }
+
+      function loadVoiceTrack(key, label) {
+        voiceCleanupPlayer.src = voiceTracks[key];
+        voiceCleanupPlayer.load();
+        voiceTrackLabel.textContent = label;
+        voicePlayPauseBtn.innerHTML = '<span class="play-icon">▶️</span>';
+        voiceTrackTime.textContent = `0:00 / 0:00`;
+      }
+
+      voiceTrackButtons.forEach((btn) => {
+        btn.addEventListener("click", () => {
+          voiceTrackButtons.forEach((b) => b.classList.remove("active"));
+          btn.classList.add("active");
+          loadVoiceTrack(
+            btn.dataset.track,
+            btn.querySelector(".track-label").textContent,
+          );
+          voiceCleanupPlayer.play();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
+        });
+      });
+
+      voicePlayPauseBtn.addEventListener("click", () => {
+        if (voiceCleanupPlayer.paused) {
+          voiceCleanupPlayer.play();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
+        } else {
+          voiceCleanupPlayer.pause();
+          voicePlayPauseBtn.innerHTML = '<span class="play-icon">▶️</span>';
+        }
+      });
+
+      voiceCleanupPlayer.addEventListener("timeupdate", () => {
+        const progress =
+          (voiceCleanupPlayer.currentTime / voiceCleanupPlayer.duration) * 100;
+        voiceProgressFill.style.width = `${progress || 0}%`;
+        voiceTrackTime.textContent = `${formatVoiceTime(
+          voiceCleanupPlayer.currentTime,
+        )} / ${formatVoiceTime(voiceCleanupPlayer.duration)}`;
+      });
+
+      voiceCleanupPlayer.addEventListener("loadedmetadata", () => {
+        voiceTrackTime.textContent = `0:00 / ${formatVoiceTime(
+          voiceCleanupPlayer.duration,
+        )}`;
+      });
+
+      voiceVolumeSlider.addEventListener("input", () => {
+        voiceCleanupPlayer.volume = voiceVolumeSlider.value / 100;
+      });
+
+      loadVoiceTrack("ai", "AI Clean");
+    </script>
+    <script>
+      const ctaButtons = document.querySelectorAll(
+        ".cta-buttons .retro-button",
+      );
+      function pulseButtons() {
+        ctaButtons.forEach((btn) => btn.classList.add("pulse"));
+        setTimeout(() => {
+          ctaButtons.forEach((btn) => btn.classList.remove("pulse"));
+        }, 10000);
+      }
+      pulseButtons();
+      setInterval(pulseButtons, 60000);
+    </script>
+    <script>
+      const blobs = document.querySelectorAll(".blob");
+      function moveBlob(b) {
+        const x = Math.random() * 100 - 50;
+        const y = Math.random() * 100 - 50;
+        b.style.transform = `translate(${x}vw, ${y}vh)`;
+      }
+      blobs.forEach((b) => {
+        setTimeout(() => moveBlob(b), 100);
+        setInterval(() => moveBlob(b), 30000);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Hebrew and Russian versions of the voice cleanup offer page with localized copy, audio player, and intake form
- update the English voice cleanup offer navigation to reference the localized pages and mark the current offer link
- localize the dynamically injected voice cleanup dropdown link based on the document language

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f95990ed7c832dba0af75b2b224582