### PR TITLE
Fix mobile navigation toggle on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,8 +162,6 @@
       </div>
     </footer>
     <script src="nav.js"></script>
-  
-    <script src="nav.js"></script>
     <script>
       const ctaButtons = document.querySelectorAll(
         ".cta-buttons .retro-button",


### PR DESCRIPTION
## Summary
- remove the duplicate nav.js include on the home page so the mobile toggle only runs once

## Testing
- browser_container.run_playwright_script(viewport=375x812)

------
https://chatgpt.com/codex/tasks/task_e_68f9ec409fe4832db66c1f8755ca52d2