### PR TITLE
Update voice cleanup audio and labels

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -183,7 +183,7 @@
         <div class="audio-player-container">
           <div class="track-buttons">
             <button class="track-btn active" data-track="fixed">
-                            <span class="track-label">Fixed</span>
+                            <span class="track-label">Clean</span>
             </button>
             <button class="track-btn" data-track="original">
               
@@ -342,7 +342,7 @@
         audioPlayer.volume = volumeSlider.value / 100;
       });
 
-      loadTrack("fixed", "My Fix + AI");
+      loadTrack("fixed", "Clean");
     </script>
     <script>
       const ctaButtons = document.querySelectorAll(

--- a/voicecleanupoffer.html
+++ b/voicecleanupoffer.html
@@ -97,7 +97,7 @@
             <div class="audio-player-container">
               <div class="track-buttons">
                 <button class="track-btn active" data-track="ai">
-                  <span class="track-label">AI Clean</span>
+                  <span class="track-label">Clean</span>
                 </button>
                 <button class="track-btn" data-track="original">
                   <span class="track-label">Original</span>
@@ -105,7 +105,7 @@
               </div>
               <div class="audio-player">
                 <div class="player-info">
-                  <span class="current-track">AI Clean</span>
+                  <span class="current-track">Clean</span>
                   <span class="track-time">0:00 / 0:00</span>
                 </div>
                 <div class="player-controls">
@@ -132,7 +132,7 @@
             </div>
             <audio id="voiceCleanupPlayer" preload="metadata">
               <source
-                src="Just%20AI.mp3"
+                src="My%20fix%20plus%20AI.mp3"
                 type="audio/mpeg"
                 data-track="ai"
               />
@@ -230,7 +230,7 @@
       );
 
       const voiceTracks = {
-        ai: "Just%20AI.mp3",
+        ai: "My%20fix%20plus%20AI.mp3",
         original: "Original.mp3",
       };
 
@@ -290,7 +290,7 @@
         voiceCleanupPlayer.volume = voiceVolumeSlider.value / 100;
       });
 
-      loadVoiceTrack("ai", "AI Clean");
+      loadVoiceTrack("ai", "Clean");
     </script>
     <script>
       const ctaButtons = document.querySelectorAll(


### PR DESCRIPTION
## Summary
- point the voice cleanup player at the corrected "My fix plus AI.mp3" file
- rename the voice cleanup track button and label to "Clean" on both the offer and portfolio pages

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125512f3a0832d8af064825e16acdb)