### PR TITLE
Stack cards vertically and update navigation

### DIFF
--- a/aboutme.html
+++ b/aboutme.html
@@ -35,11 +35,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers <span class="arrow">&gt;</span></a
+              >Services <span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
             </div>
           </div>

--- a/aivideooffer.htm
+++ b/aivideooffer.htm
@@ -45,11 +45,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers <span class="arrow">&gt;</span></a
+              >Services <span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
             </div>
           </div>

--- a/he/aboutme.html
+++ b/he/aboutme.html
@@ -41,7 +41,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">פוסט אודיו</a>
-              <a href="https://tonys.lovabel.app">אוטומציה</a>
               <a href="aivideooffer.html">וידאו AI</a>
             </div>
           </div>

--- a/he/aivideooffer.html
+++ b/he/aivideooffer.html
@@ -52,7 +52,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">פוסט אודיו</a>
-              <a href="https://tonys.lovabel.app">אוטומציה</a>
               <a href="aivideooffer.html" aria-current="page">וידאו AI</a>
             </div>
           </div>

--- a/he/index.html
+++ b/he/index.html
@@ -53,7 +53,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">פוסט אודיו</a>
-              <a href="https://tonys.lovabel.app">אוטומציה</a>
               <a href="aivideooffer.html">וידאו AI</a>
             </div>
           </div>

--- a/he/portfolio.html
+++ b/he/portfolio.html
@@ -53,7 +53,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">פוסט אודיו</a>
-              <a href="https://tonys.lovabel.app">אוטומציה</a>
               <a href="aivideooffer.html">וידאו AI</a>
             </div>
           </div>

--- a/he/privacy.html
+++ b/he/privacy.html
@@ -41,7 +41,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">פוסט אודיו</a>
-              <a href="https://tonys.lovabel.app">אוטומציה</a>
               <a href="aivideooffer.html">וידאו AI</a>
             </div>
           </div>

--- a/he/taudiomagic.html
+++ b/he/taudiomagic.html
@@ -52,7 +52,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html" aria-current="page">פוסט אודיו</a>
-              <a href="https://tonys.lovabel.app">אוטומציה</a>
               <a href="aivideooffer.html">וידאו AI</a>
             </div>
           </div>

--- a/he/voicecleanupoffer.html
+++ b/he/voicecleanupoffer.html
@@ -52,7 +52,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">פוסט אודיו</a>
-              <a href="https://tonys.lovabel.app">אוטומציה</a>
               <a href="aivideooffer.html">וידאו AI</a>
               <a
                 href="voicecleanupoffer.html"

--- a/index.html
+++ b/index.html
@@ -47,11 +47,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers&nbsp;<span class="arrow">&gt;</span></a
+              >Services&nbsp;<span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
             </div>
           </div>

--- a/portfolio.html
+++ b/portfolio.html
@@ -47,11 +47,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers <span class="arrow">&gt;</span></a
+              >Services <span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
             </div>
           </div>

--- a/privacy.html
+++ b/privacy.html
@@ -33,11 +33,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers <span class="arrow">&gt;</span></a
+              >Services <span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
             </div>
           </div>

--- a/privacy_en.html
+++ b/privacy_en.html
@@ -33,11 +33,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers <span class="arrow">&gt;</span></a
+              >Services <span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
             </div>
           </div>

--- a/privacy_he.html
+++ b/privacy_he.html
@@ -34,11 +34,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers <span class="arrow">&gt;</span></a
+              >Services <span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
             </div>
           </div>

--- a/ru/aboutme.html
+++ b/ru/aboutme.html
@@ -41,7 +41,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Аудио пост-продакшн</a>
-              <a href="https://tonys.lovabel.app">Автоматизация</a>
               <a href="aivideooffer.html">AI видео</a>
             </div>
           </div>

--- a/ru/aivideooffer.html
+++ b/ru/aivideooffer.html
@@ -52,7 +52,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Аудио пост-продакшн</a>
-              <a href="https://tonys.lovabel.app">Автоматизация</a>
               <a href="aivideooffer.html" aria-current="page">AI видео</a>
             </div>
           </div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -53,7 +53,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Аудио пост-продакшн</a>
-              <a href="https://tonys.lovabel.app">Автоматизация</a>
               <a href="aivideooffer.html">AI видео</a>
             </div>
           </div>

--- a/ru/portfolio.html
+++ b/ru/portfolio.html
@@ -53,7 +53,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Аудио пост-продакшн</a>
-              <a href="https://tonys.lovabel.app">Автоматизация</a>
               <a href="aivideooffer.html">AI видео</a>
             </div>
           </div>

--- a/ru/privacy.html
+++ b/ru/privacy.html
@@ -36,11 +36,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers <span class="arrow">&gt;</span></a
+              >Services <span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Аудио пост-продакшн</a>
-              <a href="https://tonys.lovabel.app">Автоматизация</a>
               <a href="aivideooffer.html">AI видео</a>
             </div>
           </div>

--- a/ru/taudiomagic.html
+++ b/ru/taudiomagic.html
@@ -52,7 +52,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html" aria-current="page">Аудио пост-продакшн</a>
-              <a href="https://tonys.lovabel.app">Автоматизация</a>
               <a href="aivideooffer.html">AI видео</a>
             </div>
           </div>

--- a/ru/voicecleanupoffer.html
+++ b/ru/voicecleanupoffer.html
@@ -52,7 +52,6 @@
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Аудио постпродакшн</a>
-              <a href="https://tonys.lovabel.app">Автоматизация</a>
               <a href="aivideooffer.html">Видеопредложение AI</a>
               <a
                 href="voicecleanupoffer.html"

--- a/style.css
+++ b/style.css
@@ -8,6 +8,8 @@
   --color-highlight: #27050f;
   --color-contrast: #050505;
   --dark-gray: #333333;
+  --card-side-margin: 16.666vw;
+  --card-vertical-gap: 2.5rem;
 }
 
 :focus-visible { /* CHANGED from :focus */
@@ -32,8 +34,8 @@ body {
   color: var(--color-contrast);
   padding-top: 8vh;
   padding-bottom: 8vh;
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding-left: 0;
+  padding-right: 0;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -93,92 +95,95 @@ body > * {
 }
 /* Card layout */
 
-.cards-row {
-  display: flex;
-  align-items: stretch;
-  gap: 0.25rem; /* space between columns */
-}
-
 .cards-column {
   flex: 1;
   display: flex;
-  align-items: stretch;
   flex-direction: column;
-  gap: 0.25rem; /* space between cards */
+  gap: 0;
+  padding-block: calc(var(--card-vertical-gap) / 2);
+}
+
+.cards-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
 /* Card component */
-.card {
+.card,
+.offer-card {
   background: transparent;
   color: var(--color-contrast);
   border: none;
   border-radius: 0;
   box-shadow: none;
-  margin: 0.25rem 0.25rem;
   padding: 0;
-  width: 100%;
+  width: auto;
+  margin: calc(var(--card-vertical-gap) / 2) var(--card-side-margin);
   display: flex;
   flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
 }
 
 .card-content {
   flex: 1;
-  padding: 0.25rem;
+  width: 100%;
+  padding: 0 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.card iframe {
+.card img,
+.card iframe,
+.offer-card iframe {
   width: 100%;
   height: auto;
   aspect-ratio: 16/9;
   display: block;
-}
-
-/* Horizontal card variant */
-.cards-column .card {
-  flex-direction: row;
-  overflow: hidden;
-}
-
-.cards-column .card img {
-  flex: 1;
-  width: 50%;
   object-fit: cover;
-  margin: 0;
 }
 
-.cards-column .card .card-content {
-  line-height: 1.4;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  white-space: normal;
+.card img {
+  border-radius: 0;
+}
+
+.card p,
+.card h2,
+.card h3,
+.card h4,
+.card-content p,
+.offer-card p,
+.offer-card h2,
+.offer-card h3,
+.offer-card h4 {
+  text-align: center;
+}
+
+.card ul,
+.offer-card ul {
+  list-style-position: inside;
+  padding-left: 0;
+  margin: 0 auto;
+  text-align: center;
 }
 
 /* Portfolio page adjustments */
 .portfolio-page .card {
   flex-direction: column;
-  padding-left: 1rem;
   overflow: visible;
+  padding: 0;
 }
 
 .portfolio-grid,
 .portfolio-grid .pair {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-}
-
-@media (pointer: fine) {
-  .portfolio-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 2%;
-  }
-
-  .portfolio-grid .pair {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 2%;
-  }
+  gap: 0;
+  align-items: stretch;
+  padding-block: calc(var(--card-vertical-gap) / 2);
 }
 
 @media (max-width: 768px) {
@@ -200,50 +205,12 @@ body > * {
     margin-right: 1%;
     width: 98%;
   }
-  .card,
-  .card iframe {
-    margin: 1%;
-    width: 98%;
-  }
 }
 
-@media (max-width: 768px) and (orientation: portrait) {
-  .cards-row {
-    flex-direction: column;
-  }
-  .cards-column .card {
-    flex-direction: column;
-    align-items: center;
-  }
-  .card h3 {
-    text-align: center;
-    width: 100%;
-    margin-bottom: 1vh;
-  }
-  .card,
-  .card iframe {
-    width: 90%;
-    margin: 1rem auto;
-  }
-  .card .skills {
-    margin: 1rem 1rem;
-  }
-  .portfolio-grid .card {
-    margin-bottom: 1rem;
-  }
-}
-
-@media (max-width: 768px) and (orientation: landscape) {
-  .cards-row {
-    flex-direction: row;
-  }
-  .cards-column .card {
-    flex-direction: row;
-  }
-  .card h3 {
-    text-align: left;
-    width: auto;
-    margin-bottom: 0;
+@media (orientation: portrait) {
+  :root {
+    --card-side-margin: 4vw;
+    --card-vertical-gap: 2rem;
   }
 }
 
@@ -467,12 +434,12 @@ html[dir="rtl"] .dropdown-content {
   right: 0;
 }
 
-html[dir="rtl"] .cards-row {
-  flex-direction: row-reverse;
-}
-
-html[dir="rtl"] .cards-column .card {
-  flex-direction: row-reverse;
+html[dir="rtl"] .cards-row,
+html[dir="rtl"] .cards-column .card,
+html[dir="rtl"] .card,
+html[dir="rtl"] .offer-card {
+  flex-direction: column;
+  text-align: center;
 }
 
 html[dir="rtl"] .portfolio-grid .pair {
@@ -1148,7 +1115,7 @@ footer {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2rem;
+  gap: 0;
   margin-top: 2rem;
 }
 
@@ -1180,4 +1147,9 @@ footer {
   .voice-cleanup-page .form-embed iframe {
     min-height: 28rem;
   }
+}
+.card > *:not(img):not(iframe),
+.offer-card > *:not(img):not(iframe) {
+  width: 100%;
+  padding-inline: 1.5rem;
 }

--- a/taudiomagic.html
+++ b/taudiomagic.html
@@ -46,11 +46,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers <span class="arrow">&gt;</span></a
+              >Services <span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
             </div>
           </div>

--- a/voicecleanupoffer.html
+++ b/voicecleanupoffer.html
@@ -46,11 +46,10 @@
         <div class="nav-left">
           <div class="nav-dropdown">
             <a href="#" class="nav-btn" aria-haspopup="true" aria-expanded="false"
-              >Offers&nbsp;<span class="arrow">&gt;</span></a
+              >Services&nbsp;<span class="arrow">&gt;</span></a
             >
             <div class="dropdown-content">
               <a href="taudiomagic.html">Audio Post-</a>
-              <a href="https://tonys.lovabel.app">Automation</a>
               <a href="aivideooffer.htm">AI Video Offer</a>
               <a
                 href="voicecleanupoffer.html"


### PR DESCRIPTION
## Summary
- restyle card components so each page displays single-column cards with centered content and responsive viewport margins
- adjust portfolio and voice cleanup layouts to follow the unified card spacing rules
- rename the Offers dropdown to Services and remove the automation link across all locales

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912765b3b4c832db0d31b2377a152f0)