### PR TITLE
Adjust AI video embed layout

### DIFF
--- a/aivideoprod.html
+++ b/aivideoprod.html
@@ -58,6 +58,7 @@
 
       <div class="card">
         <iframe
+          style="--embed-aspect: 4 / 5;"
           src="https://www.youtube.com/embed/71IY9Bhcccc?controls=0"
           title="AI Video Production Demo"
           frameborder="0"

--- a/he/aivideoprod.html
+++ b/he/aivideoprod.html
@@ -66,6 +66,7 @@
 
       <div class="card">
         <iframe
+          style="--embed-aspect: 4 / 5;"
           src="https://www.youtube.com/embed/71IY9Bhcccc?controls=0"
           title="AI Video Production Demo"
           frameborder="0"

--- a/ru/aivideoprod.html
+++ b/ru/aivideoprod.html
@@ -66,6 +66,7 @@
 
       <div class="card">
         <iframe
+          style="--embed-aspect: 4 / 5;"
           src="https://www.youtube.com/embed/8Oj5uAMVpLQ?controls=0"
           title="AI Video Production Demo"
           frameborder="0"

--- a/style.css
+++ b/style.css
@@ -17,6 +17,7 @@
   --card-min-height: auto;
   --card-justify: flex-start;
   --card-padding: 0;
+  --iframe-inline-size: 80%;
 }
 
 :focus-visible { /* CHANGED from :focus */
@@ -49,7 +50,15 @@ body {
   align-items: stretch;
 }
 
-iframe,
+iframe {
+  display: block;
+  width: var(--iframe-inline-size, 100%);
+  max-width: var(--iframe-inline-size, 100%);
+  margin-inline: auto;
+  height: auto;
+  aspect-ratio: var(--embed-aspect, 16 / 9);
+}
+
 video {
   display: block;
   width: 100%;
@@ -99,8 +108,8 @@ body > * {
   flex: 1 0 auto;
   display: flex;
   flex-direction: column;
-  margin-left: 5vw;  /* 1/6 экрана слева */
-  margin-right: 5vw; /* 1/6 экрана справа */
+  margin-left: 10vw;  /* увеличенный отступ слева */
+  margin-right: 10vw; /* увеличенный отступ справа */
 }
 
 .landing .page-content {
@@ -119,9 +128,9 @@ body > * {
 .form-embed {
   --embed-aspect: 100 / 65.1042;
   position: relative;
-  width: 100%;
+  width: var(--iframe-inline-size, 100%);
   aspect-ratio: var(--embed-aspect);
-  margin: 1.6em 0 0.9em;
+  margin: 1.6em auto 0.9em;
   overflow: hidden;
   border-radius: 1rem;
   box-shadow: 0 2px 8px rgba(63, 69, 81, 0.16);
@@ -300,17 +309,21 @@ body > * {
   gap: 1rem;
 }
 
-.card img,
-.card iframe,
-.offer-card iframe {
+.card img {
   width: 100%;
   height: auto;
   display: block;
   object-fit: cover;
+  border-radius: 0;
 }
 
-.card img {
-  border-radius: 0;
+.card iframe,
+.offer-card iframe {
+  width: var(--iframe-inline-size, 100%);
+  max-width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
 }
 
 .card p,
@@ -371,7 +384,11 @@ body > * {
   .card,
   .card iframe {
     margin: 1%;
-    width: 98%;
+  }
+
+  .card iframe {
+    width: var(--iframe-inline-size, 100%);
+    margin-inline: auto;
   }
 }
 
@@ -885,8 +902,8 @@ footer {
   .page-content {
     padding-left: 1rem;
     padding-right: 1rem;
-	margin-left: 1vw;  /* 1/6 экрана слева */
-    margin-right: 1vw; /* 1/6 экрана справа */
+    margin-left: 2vw;  /* увеличенный отступ слева */
+    margin-right: 2vw; /* увеличенный отступ справа */
   }
 
   .social-links {
@@ -1131,7 +1148,9 @@ footer {
 
 .video-wrapper {
   position: relative;
+  width: var(--iframe-inline-size, 100%);
   padding-top: 56.25%;
+  margin-inline: auto;
 }
 
 .video-wrapper iframe {


### PR DESCRIPTION
## Summary
- increase horizontal body gutters by doubling the page-content margins on desktop and mobile
- scale iframe embeds to 80% width and center embed containers, including video wrappers and form blocks
- apply a 4:5 aspect ratio to the AI video demo iframes across the localized offer pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158ecfc35c832d8db3f22e952a36b6)