### PR TITLE
Apply vertical video card markup to AI production pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@
 - **JS**: Vanilla modules with `defer`. Names: camelCase for variables/functions, PascalCase for classes. Attach behavior via `data-*` hooks (e.g., `[data-nav-toggle]`) and use event delegation.
 - **Files**: kebab-case filenames (`hero-banner.html`, `site-header.css`). Use relative paths from the page.
 
+### Vertical video cards
+- Use the `.card card--vertical-video` pattern for every vertical video embed.
+- Nest the media inside `.vertical-video-card > .vertical-video-card__frame > .vertical-video-card__media-wrapper` and apply the `vertical-video-card__media` class to the `<video>` or `<iframe>` element so it inherits the 9:16 aspect ratio and max width (one third of the viewport on desktop, full width on narrow screens).
+- Keep supporting copy inside `.vertical-video-card__caption`. If no caption is required, leave the element empty but keep the structure for consistent spacing.
+
 ## Testing Guidelines
 - Validate HTML/CSS (W3C Validators). Check console for errors and 404s.
 - Responsive checks at 320, 768, 1024, 1440 px. Test keyboard navigation and focus states.

--- a/aivideoprod.html
+++ b/aivideoprod.html
@@ -56,16 +56,26 @@
         
       </header>
 
-      <div class="card">
-        <iframe
-          style="--embed-aspect: 4 / 5;"
-          src="https://www.youtube.com/embed/ibJ-_whpSQk?controls=0"
-          title="AI Video Production Demo"
-          frameborder="0"
-          allow="encrypted-media; web-share"
-          referrerpolicy="strict-origin-when-cross-origin"
-          allowfullscreen
-        ></iframe>
+      <div class="card card--vertical-video">
+        <div class="vertical-video-card">
+          <figure class="vertical-video-card__frame">
+            <div class="vertical-video-card__media-wrapper">
+              <iframe
+                class="vertical-video-card__media"
+                style="--embed-aspect: 4 / 5;"
+                src="https://www.youtube.com/embed/ibJ-_whpSQk?controls=0"
+                title="AI Video Production Demo"
+                frameborder="0"
+                allow="encrypted-media; web-share"
+                referrerpolicy="strict-origin-when-cross-origin"
+                allowfullscreen
+              ></iframe>
+            </div>
+            <figcaption class="vertical-video-card__caption">
+              A 9:16 showcase of our AI-driven live-action workflow.
+            </figcaption>
+          </figure>
+        </div>
       </div>
       <br />
 

--- a/he/aivideoprod.html
+++ b/he/aivideoprod.html
@@ -64,16 +64,26 @@
         <h1>הפקת וידאו בינה מלאכותית</h1>
       </header>
 
-      <div class="card">
-        <iframe
-          style="--embed-aspect: 4 / 5;"
-          src="https://www.youtube.com/embed/ibJ-_whpSQk?controls=0"
-          title="AI Video Production Demo"
-          frameborder="0"
-          allow="encrypted-media; web-share"
-          referrerpolicy="strict-origin-when-cross-origin"
-          allowfullscreen
-        ></iframe>
+      <div class="card card--vertical-video">
+        <div class="vertical-video-card">
+          <figure class="vertical-video-card__frame">
+            <div class="vertical-video-card__media-wrapper">
+              <iframe
+                class="vertical-video-card__media"
+                style="--embed-aspect: 4 / 5;"
+                src="https://www.youtube.com/embed/ibJ-_whpSQk?controls=0"
+                title="AI Video Production Demo"
+                frameborder="0"
+                allow="encrypted-media; web-share"
+                referrerpolicy="strict-origin-when-cross-origin"
+                allowfullscreen
+              ></iframe>
+            </div>
+            <figcaption class="vertical-video-card__caption">
+              דוגמה אנכית של זרימת העבודה הקולנועית שלנו עם AI.
+            </figcaption>
+          </figure>
+        </div>
       </div>
       <br />
 

--- a/ru/aivideoprod.html
+++ b/ru/aivideoprod.html
@@ -64,16 +64,26 @@
         <h1>AI-видеопроизводство</h1>
       </header>
 
-      <div class="card">
-        <iframe
-          style="--embed-aspect: 4 / 5;"
-          src="https://www.youtube.com/embed/8Oj5uAMVpLQ?controls=0"
-          title="AI Video Production Demo"
-          frameborder="0"
-          allow="encrypted-media; web-share"
-          referrerpolicy="strict-origin-when-cross-origin"
-          allowfullscreen
-        ></iframe>
+      <div class="card card--vertical-video">
+        <div class="vertical-video-card">
+          <figure class="vertical-video-card__frame">
+            <div class="vertical-video-card__media-wrapper">
+              <iframe
+                class="vertical-video-card__media"
+                style="--embed-aspect: 4 / 5;"
+                src="https://www.youtube.com/embed/8Oj5uAMVpLQ?controls=0"
+                title="AI Video Production Demo"
+                frameborder="0"
+                allow="encrypted-media; web-share"
+                referrerpolicy="strict-origin-when-cross-origin"
+                allowfullscreen
+              ></iframe>
+            </div>
+            <figcaption class="vertical-video-card__caption">
+              Вертикальный пример нашего кинематографичного AI-процесса.
+            </figcaption>
+          </figure>
+        </div>
       </div>
       <br />
 

--- a/style.css
+++ b/style.css
@@ -67,6 +67,63 @@ video {
   aspect-ratio: var(--embed-aspect, 16 / 9);
 }
 
+.card--vertical-video {
+  --card-padding: clamp(1.5rem, 4vw, 2.5rem);
+  --embed-aspect: 9 / 16;
+  gap: 1.25rem;
+}
+
+.card--vertical-video .vertical-video-card {
+  width: min(100%, 33vw);
+  display: flex;
+  justify-content: center;
+  margin-inline: auto;
+}
+
+.vertical-video-card__frame {
+  width: 100%;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0;
+  align-items: stretch;
+}
+
+.vertical-video-card__media-wrapper {
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  overflow: hidden;
+  display: flex;
+}
+
+.vertical-video-card__media {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.vertical-video-card__caption {
+  font-size: clamp(0.9rem, 1.8vw, 1rem);
+  line-height: 1.4;
+}
+
+.vertical-video-card__caption:empty {
+  display: none;
+}
+
+@media (max-width: 960px) {
+  .card--vertical-video .vertical-video-card {
+    width: min(100%, 50vw);
+  }
+}
+
+@media (max-width: 640px) {
+  .card--vertical-video .vertical-video-card {
+    width: 100%;
+  }
+}
+
 form {
   width: 100%;
   max-width: 100%;


### PR DESCRIPTION
## Summary
- revert the landing page to its previous layout without the experimental vertical video card
- wrap the AI video embeds on all language variants in the shared vertical video card structure for consistent sizing

## Testing
- not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d16ba514832d91602e8d420e11dc)