### PR TITLE
Sync localized pages with refreshed hero layout

### DIFF
--- a/aivideoprod.html
+++ b/aivideoprod.html
@@ -71,9 +71,7 @@
                 allowfullscreen
               ></iframe>
             </div>
-            <figcaption class="vertical-video-card__caption">
-              דוגמה אנכית של זרימת העבודה הקולנועית שלנו עם AI.
-            </figcaption>
+            <figcaption class="vertical-video-card__caption"></figcaption>
           </figure>
       
         </div>

--- a/he/aivideoprod.html
+++ b/he/aivideoprod.html
@@ -79,9 +79,7 @@
                 allowfullscreen
               ></iframe>
             </div>
-            <figcaption class="vertical-video-card__caption">
-              דוגמה אנכית של זרימת העבודה הקולנועית שלנו עם AI.
-            </figcaption>
+            <figcaption class="vertical-video-card__caption"></figcaption>
           </figure>
         </div>
       </div>

--- a/he/index.html
+++ b/he/index.html
@@ -71,7 +71,7 @@
       </nav>
     </header>
     <main class="page-content">
-      <section class="card">
+      <section class="card hero-card">
         <h1>Tony's Media and Automation</h1>
       </section>
 

--- a/he/portfolio.html
+++ b/he/portfolio.html
@@ -72,14 +72,13 @@
     </header>
 
     <main class="page-content">
-<header>
-      <h1>תיק עבודות</h1>
-      <div class="tagline">עבודות נבחרות וניסויים</div>
-          <br>
-    </header>
+      <header>
+        <h1>תיק עבודות</h1>
+        <div class="tagline">עבודות נבחרות וניסויים</div>
+        <br />
+      </header>
 
-    <div class="portfolio-grid">
-      <div class="pair">
+      <div class="portfolio-grid">
         <div class="card">
           <iframe
             src="https://www.youtube.com/embed/GuHLzmP-xZM?si=kiJv0iSBKVFYjuvb&amp;controls=0"
@@ -90,103 +89,91 @@
             allowfullscreen
           ></iframe>
         </div>
-        <div class="card">
+        <div class="tagline">
           <h3>פרסומת AI</h3>
-          <ul class="skills">
-            <li>עריכת וידאו</li>
-            <li>גרפיקה מונפשת</li>
-            <li>עיצוב סאונד ומיקס</li>
-            <li>מוצר עקבי</li>
-            <li>הפקת וידאו ב‑AI</li>
-            <li>הפקת מוזיקה ב‑AI</li>
-            <li>הפקת קריינות ב‑AI</li>
-            <li>הנדסת פרומפטים ב‑JSON</li>
-          </ul>
         </div>
-      </div>
-      <div class="pair">
-        <div class="card">
-          <iframe
-            src="https://www.youtube.com/embed/9qeGSeha-LU?si=IDDWZhn9TedBIHfl&amp;controls=0"
-            title="Sound Design Explained"
-            frameborder="0"
-            allow="encrypted-media; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
+
+        <div class="card card--vertical-video">
+          <div class="vertical-video-card">
+            <figure class="vertical-video-card__frame">
+              <div class="vertical-video-card__media-wrapper">
+                <iframe
+                  class="vertical-video-card__media"
+                  style="--embed-aspect: 4 / 5;"
+                  src="https://www.youtube.com/embed/VL5MwFb7tFs?si=MjCCfPnCX0roT262"
+                  title="AI Video Production Demo"
+                  frameborder="0"
+                  allow="encrypted-media; web-share"
+                  referrerpolicy="strict-origin-when-cross-origin"
+                  allowfullscreen
+                ></iframe>
+              </div>
+              <figcaption class="vertical-video-card__caption">
+                סרטון אנכי שמדגים את תהליך ה-AI שלנו.
+              </figcaption>
+            </figure>
+          </div>
         </div>
-        <div class="card">
-          <h3>סרטון הסברה</h3>
-          <ul class="skills">
-            <li>עריכת וידאו</li>
-            <li>גרפיקה מונפשת</li>
-            <li>עיצוב סאונד</li>
-            <li>מיקס סאונד</li>
-            <li>כתיבת תסריט</li>
-            <li>שיקום קריינות</li>
-          </ul>
+        <div class="tagline">
+          <h3>קליפ מוזיקלי</h3>
         </div>
-      </div>
-      <div class="pair">
+
         <div class="card">
           <iframe
             src="https://www.youtube.com/embed/JzXSnLSNEqQ?si=Btwrnq-sYxhtq4AE&amp;controls=0"
-            title="NotebookLM"
+            title="NotebookLM review video"
             frameborder="0"
             allow="encrypted-media; web-share"
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
           ></iframe>
         </div>
-        <div class="card">
+        <div class="tagline">
           <h3>סקירת וידאו</h3>
-          <ul class="skills">
-            <li>עריכת וידאו</li>
-            <li>גרפיקה מונפשת</li>
-            <li>עיצוב סאונד ומיקס</li>
-            <li>הפקת וידאו ב‑AI</li>
-            <li>הפקת מוזיקה ב‑AI</li>
-            <li>הפקת קריינות ב‑AI</li>
-          </ul>
         </div>
-      </div>
-      <div class="pair">
+
         <div class="card">
           <iframe
             src="https://www.youtube.com/embed/wr8Q-fQHlRs?si=hYBLh7B38Zai1QWq&amp;controls=0"
-            title="Mikhoels suitcase"
+            title="Mikhoels' suitcase"
             frameborder="0"
             allow="encrypted-media; web-share"
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
           ></iframe>
         </div>
-        <div class="card">
+        <div class="tagline">
           <h3>הפקה דוקומנטרית</h3>
-          <ul class="skills">
-            <li>עריכת וידאו</li>
-            <li>גרפיקה מונפשת</li>
-            <li>עיצוב סאונד ומיקס</li>
-            <li>תיקון צבע</li>
-            <li>שיקום חומרי ארכיון</li>
-            <li>שיקום קריינות</li>
-          </ul>
+        </div>
+
+        <div class="card">
+          <iframe
+            src="https://www.youtube.com/embed/KjNlmT_eDqY?si=Vn9lusQ4Cja8nNqW"
+            title="Silent solitude"
+            frameborder="0"
+            allow="encrypted-media; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <div class="tagline">
+          <h3>קליפ מוזיקלי</h3>
         </div>
       </div>
-<div class="audio-demo">
+
+      <!--
+      <div class="audio-demo">
         <h3 class="demo-title">שיקום אודיו</h3>
         <p class="demo-subtitle">הקול שלכם יכול להיות נקי בכל סיטואציה</p>
 
         <div class="audio-player-container">
           <div class="track-buttons">
             <button class="track-btn active" data-track="fixed">
-                            <span class="track-label">אחרי תיקון</span>
+              <span class="track-label">אחרי תיקון</span>
             </button>
             <button class="track-btn" data-track="original">
-
               <span class="track-label">מקורי</span>
             </button>
-
           </div>
 
           <div class="audio-player">
@@ -218,8 +205,8 @@
               </div>
             </div>
           </div>
-                  </div>
-                  <audio id="audioPlayer" preload="metadata">
+        </div>
+        <audio id="audioPlayer" preload="metadata">
           <source
             src="../My%20fix%20plus%20AI.mp3"
             type="audio/mpeg"
@@ -227,20 +214,10 @@
           />
           <source src="../Original.mp3" type="audio/mpeg" data-track="original" />
           <source src="../Just%20AI.mp3" type="audio/mpeg" data-track="ai" />
-          הדפדפן שלכם אינו תומך בנגן האודיו.
+          הדפדפן שלכם לא תומך בנגן אודיו.
         </audio>
-    </div>
-        <div class="card">
-          <h3>שיקום אודיו</h3>
-          <ul class="skills">
-            <li>ניקוי חומר גלם</li>
-            <li>הסרת רעשים</li>
-            <li>איזון ואקולייזציה</li>
-            <li>התאמת עוצמות</li>
-            <li>שיקום חומרי ארכיון</li>
-            </ul>
-        </div>
-
+      </div>
+      -->
     </main>
     <div class="cta-buttons">
       <a
@@ -258,7 +235,7 @@
         <i class="fa-brands fa-whatsapp"></i>
       </a>
     </div>
-<br><br><br>
+    <br /><br /><br />
     <footer>
       <div class="social-links">
         <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
@@ -315,7 +292,7 @@
         });
       });
 
-      playPauseBtn.addEventListener("click", () => {
+      playPauseBtn?.addEventListener("click", () => {
         if (audioPlayer.paused) {
           audioPlayer.play();
           playPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
@@ -325,21 +302,25 @@
         }
       });
 
-      audioPlayer.addEventListener("timeupdate", () => {
+      audioPlayer?.addEventListener("timeupdate", () => {
         const progress = (audioPlayer.currentTime / audioPlayer.duration) * 100;
-        progressFill.style.width = `${progress || 0}%`;
+        if (progressFill) {
+          progressFill.style.width = `${progress || 0}%`;
+        }
         trackTime.textContent = `${formatTime(audioPlayer.currentTime)} / ${formatTime(audioPlayer.duration)}`;
       });
 
-      audioPlayer.addEventListener("loadedmetadata", () => {
+      audioPlayer?.addEventListener("loadedmetadata", () => {
         trackTime.textContent = `0:00 / ${formatTime(audioPlayer.duration)}`;
       });
 
-      volumeSlider.addEventListener("input", () => {
+      volumeSlider?.addEventListener("input", () => {
         audioPlayer.volume = volumeSlider.value / 100;
       });
 
-      loadTrack("fixed", "אחרי תיקון");
+      if (audioPlayer) {
+        loadTrack("fixed", "אחרי תיקון");
+      }
     </script>
     <script>
       const ctaButtons = document.querySelectorAll(
@@ -354,5 +335,5 @@
       pulseButtons();
       setInterval(pulseButtons, 60000);
     </script>
-</body>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -67,13 +67,9 @@
       </nav>
     </header>
     <main class="page-content">
-       <div
-            style="padding: 25vw; align-items: center;scale: 200%;
-  text-align: center;">
-	   <header>
+      <section class="card hero-card">
         <h1>Tony's Media and Automation</h1>
-		</header>
-		</div>
+      </section>
       
 
       <section class="card">

--- a/ru/aivideoprod.html
+++ b/ru/aivideoprod.html
@@ -79,9 +79,7 @@
                 allowfullscreen
               ></iframe>
             </div>
-            <figcaption class="vertical-video-card__caption">
-              Вертикальный пример нашего кинематографичного AI-процесса.
-            </figcaption>
+            <figcaption class="vertical-video-card__caption"></figcaption>
           </figure>
         </div>
       </div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -71,7 +71,7 @@
       </nav>
     </header>
     <main class="page-content">
-      <section class="card">
+      <section class="card hero-card">
         <h1>Tony's Media and Automation</h1>
       </section>
 

--- a/ru/portfolio.html
+++ b/ru/portfolio.html
@@ -72,14 +72,13 @@
     </header>
 
     <main class="page-content">
-<header>
-      <h1>Портфолио</h1>
-      <div class="tagline">Выбранные работы и эксперименты</div>
-          <br>
-    </header>
+      <header>
+        <h1>Портфолио</h1>
+        <div class="tagline">Выбранные работы и эксперименты</div>
+        <br />
+      </header>
 
-    <div class="portfolio-grid">
-      <div class="pair">
+      <div class="portfolio-grid">
         <div class="card">
           <iframe
             src="https://www.youtube.com/embed/GuHLzmP-xZM?si=kiJv0iSBKVFYjuvb&amp;controls=0"
@@ -90,103 +89,91 @@
             allowfullscreen
           ></iframe>
         </div>
-        <div class="card">
+        <div class="tagline">
           <h3>AI-реклама</h3>
-          <ul class="skills">
-            <li>Видеомонтаж</li>
-            <li>Моушен-дизайн</li>
-            <li>Звуковой дизайн и сведение</li>
-            <li>Консистентный образ продукта</li>
-            <li>AI-генерация видео</li>
-            <li>AI-генерация музыки</li>
-            <li>AI-генерация озвучки</li>
-            <li>Разработка JSON-промтов</li>
-          </ul>
         </div>
-      </div>
-      <div class="pair">
-        <div class="card">
-          <iframe
-            src="https://www.youtube.com/embed/9qeGSeha-LU?si=IDDWZhn9TedBIHfl&amp;controls=0"
-            title="Sound Design Explained"
-            frameborder="0"
-            allow="encrypted-media; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
+
+        <div class="card card--vertical-video">
+          <div class="vertical-video-card">
+            <figure class="vertical-video-card__frame">
+              <div class="vertical-video-card__media-wrapper">
+                <iframe
+                  class="vertical-video-card__media"
+                  style="--embed-aspect: 4 / 5;"
+                  src="https://www.youtube.com/embed/VL5MwFb7tFs?si=MjCCfPnCX0roT262"
+                  title="AI Video Production Demo"
+                  frameborder="0"
+                  allow="encrypted-media; web-share"
+                  referrerpolicy="strict-origin-when-cross-origin"
+                  allowfullscreen
+                ></iframe>
+              </div>
+              <figcaption class="vertical-video-card__caption">
+                Вертикальный демонстрационный ролик нашего AI-процесса.
+              </figcaption>
+            </figure>
+          </div>
         </div>
-        <div class="card">
-          <h3>Обучающее видео</h3>
-          <ul class="skills">
-            <li>Видеомонтаж</li>
-            <li>Моушен-дизайн</li>
-            <li>Звуковой дизайн</li>
-            <li>Сведение звука</li>
-            <li>Написание сценария</li>
-            <li>Реставрация озвучки</li>
-          </ul>
+        <div class="tagline">
+          <h3>Музыкальное видео</h3>
         </div>
-      </div>
-      <div class="pair">
+
         <div class="card">
           <iframe
             src="https://www.youtube.com/embed/JzXSnLSNEqQ?si=Btwrnq-sYxhtq4AE&amp;controls=0"
-            title="NotebookLM"
+            title="NotebookLM review video"
             frameborder="0"
             allow="encrypted-media; web-share"
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
           ></iframe>
         </div>
-        <div class="card">
+        <div class="tagline">
           <h3>Видеообзор</h3>
-          <ul class="skills">
-            <li>Видеомонтаж</li>
-            <li>Моушен-дизайн</li>
-            <li>Звуковой дизайн и сведение</li>
-            <li>AI-генерация видео</li>
-            <li>AI-генерация музыки</li>
-            <li>AI-генерация озвучки</li>
-          </ul>
         </div>
-      </div>
-      <div class="pair">
+
         <div class="card">
           <iframe
             src="https://www.youtube.com/embed/wr8Q-fQHlRs?si=hYBLh7B38Zai1QWq&amp;controls=0"
-            title="Mikhoels suitcase"
+            title="Mikhoels' suitcase"
             frameborder="0"
             allow="encrypted-media; web-share"
             referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen
           ></iframe>
         </div>
-        <div class="card">
+        <div class="tagline">
           <h3>Документальное производство</h3>
-          <ul class="skills">
-            <li>Видеомонтаж</li>
-            <li>Моушен-графика</li>
-            <li>Звуковой дизайн и сведение</li>
-            <li>Цветокоррекция</li>
-            <li>Реставрация архивного видео</li>
-            <li>Реставрация озвучки</li>
-          </ul>
+        </div>
+
+        <div class="card">
+          <iframe
+            src="https://www.youtube.com/embed/KjNlmT_eDqY?si=Vn9lusQ4Cja8nNqW"
+            title="Silent solitude"
+            frameborder="0"
+            allow="encrypted-media; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <div class="tagline">
+          <h3>Музыкальное видео</h3>
         </div>
       </div>
-<div class="audio-demo">
+
+      <!--
+      <div class="audio-demo">
         <h3 class="demo-title">Реставрация аудио</h3>
         <p class="demo-subtitle">Ваш голос может звучать чисто при любых условиях</p>
 
         <div class="audio-player-container">
           <div class="track-buttons">
             <button class="track-btn active" data-track="fixed">
-                            <span class="track-label">После обработки</span>
+              <span class="track-label">После обработки</span>
             </button>
             <button class="track-btn" data-track="original">
-
               <span class="track-label">Оригинал</span>
             </button>
-
           </div>
 
           <div class="audio-player">
@@ -218,8 +205,8 @@
               </div>
             </div>
           </div>
-                  </div>
-                  <audio id="audioPlayer" preload="metadata">
+        </div>
+        <audio id="audioPlayer" preload="metadata">
           <source
             src="../My%20fix%20plus%20AI.mp3"
             type="audio/mpeg"
@@ -229,18 +216,8 @@
           <source src="../Just%20AI.mp3" type="audio/mpeg" data-track="ai" />
           Ваш браузер не поддерживает аудио.
         </audio>
-    </div>
-        <div class="card">
-          <h3>Реставрация аудио</h3>
-          <ul class="skills">
-            <li>Очистка исходных записей</li>
-            <li>Удаление шума</li>
-            <li>Баланс и эквализация</li>
-            <li>Коррекция громкости</li>
-            <li>Реставрация архивного материала</li>
-            </ul>
-        </div>
-
+      </div>
+      -->
     </main>
     <div class="cta-buttons">
       <a
@@ -258,7 +235,7 @@
         <i class="fa-brands fa-whatsapp"></i>
       </a>
     </div>
-<br><br><br>
+    <br /><br /><br />
     <footer>
       <div class="social-links">
         <a href="index.html"><i class="fa-solid fa-copyright"> </i>Tony's Media and Automation</a>
@@ -315,7 +292,7 @@
         });
       });
 
-      playPauseBtn.addEventListener("click", () => {
+      playPauseBtn?.addEventListener("click", () => {
         if (audioPlayer.paused) {
           audioPlayer.play();
           playPauseBtn.innerHTML = '<span class="play-icon">⏸️</span>';
@@ -325,21 +302,25 @@
         }
       });
 
-      audioPlayer.addEventListener("timeupdate", () => {
+      audioPlayer?.addEventListener("timeupdate", () => {
         const progress = (audioPlayer.currentTime / audioPlayer.duration) * 100;
-        progressFill.style.width = `${progress || 0}%`;
+        if (progressFill) {
+          progressFill.style.width = `${progress || 0}%`;
+        }
         trackTime.textContent = `${formatTime(audioPlayer.currentTime)} / ${formatTime(audioPlayer.duration)}`;
       });
 
-      audioPlayer.addEventListener("loadedmetadata", () => {
+      audioPlayer?.addEventListener("loadedmetadata", () => {
         trackTime.textContent = `0:00 / ${formatTime(audioPlayer.duration)}`;
       });
 
-      volumeSlider.addEventListener("input", () => {
+      volumeSlider?.addEventListener("input", () => {
         audioPlayer.volume = volumeSlider.value / 100;
       });
 
-      loadTrack("fixed", "После обработки");
+      if (audioPlayer) {
+        loadTrack("fixed", "После обработки");
+      }
     </script>
     <script>
       const ctaButtons = document.querySelectorAll(
@@ -354,5 +335,5 @@
       pulseButtons();
       setInterval(pulseButtons, 60000);
     </script>
-</body>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -182,6 +182,17 @@ body > * {
   --card-padding: clamp(2.5rem, 6vw, 4rem);
 }
 
+.hero-card {
+  --card-padding: clamp(3rem, 18vw, 8rem) clamp(1.5rem, 6vw, 4rem);
+  gap: clamp(1rem, 3vh, 2rem);
+  text-align: center;
+}
+
+.hero-card h1 {
+  font-size: clamp(2.75rem, 12vw, 6.5rem);
+  letter-spacing: 0.08em;
+}
+
 .hero-title {
   width: 100%;
   align-self: flex-start;
@@ -447,6 +458,12 @@ body > * {
     padding-bottom: 0;
     padding-left: 0;
     padding-right: 0;
+  }
+  .hero-card {
+    --card-padding: clamp(2rem, 12vw, 5rem) clamp(1rem, 5vw, 2.5rem);
+  }
+  .hero-card h1 {
+    font-size: clamp(2.25rem, 10vw, 4rem);
   }
   h1,
   h2,


### PR DESCRIPTION
## Summary
- add a reusable hero card layout and update all locale homepages to use it
- refresh the Russian and Hebrew portfolio pages to match the simplified video grid and guard the optional audio player script
- remove AI production video captions that mentioned “example” across locales

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f502a960832d9ba275a1b74a8374)