### PR TITLE
Highlight discounted pricing in AI video offers

### DIFF
--- a/aivideoprod.html
+++ b/aivideoprod.html
@@ -89,7 +89,10 @@
 
       <div class="offer-card" id="contact-form">
         <h2 class="section-title">Price</h2>
-        <h3>from 700$ up to 30 seconds of video</h3>
+        <h3>
+          from <span class="price-old">700$</span>
+          <span class="price-new">500$*</span> up to 30 seconds of video
+        </h3>
         <p class="price-note">*Pricing may vary and depends on the brief.</p>
         AI is a field of possibilities. <br> You can make realistic shooting.<br>Or something comletly different.
         <br /><br />

--- a/he/aivideoprod.html
+++ b/he/aivideoprod.html
@@ -95,7 +95,10 @@
 
       <div class="offer-card" id="contact-form">
         <h2 class="section-title">מחיר</h2>
-        <h3>החל מ־700$ עבור עד 30 שניות וידאו</h3>
+        <h3>
+          החל מ־<span class="price-old">700$</span>
+          <span class="price-new">500$*</span> עבור עד 30 שניות וידאו
+        </h3>
         <p class="price-note">*המחיר עשוי להשתנות בהתאם לבריף.</p>
         AI הוא עולם של אפשרויות.<br />אפשר ליצור צילום ריאליסטי<br />או משהו אחר לגמרי.
         <br /><br />

--- a/ru/aivideoprod.html
+++ b/ru/aivideoprod.html
@@ -95,7 +95,10 @@
 
       <div class="offer-card" id="contact-form">
         <h2 class="section-title">Стоимость</h2>
-        <h3>от 700$ за ролик до 30 секунд</h3>
+        <h3>
+          от <span class="price-old">700$</span>
+          <span class="price-new">500$*</span> за ролик до 30 секунд
+        </h3>
         <p class="price-note">*Финальная цена зависит от брифа.</p>
         AI — это поле возможностей.<br />Можно создать реалистичную съёмку<br />или пойти в совершенно другой стиль.
         <br /><br />

--- a/style.css
+++ b/style.css
@@ -112,6 +112,17 @@ video {
   display: none;
 }
 
+.price-old {
+  text-decoration: line-through;
+  color: var(--dark-gray);
+  font-weight: 500;
+}
+
+.price-new {
+  color: #c62828;
+  font-weight: 700;
+}
+
 @media (max-width: 960px) {
   .card--vertical-video .vertical-video-card {
     width: min(100%, 50vw);


### PR DESCRIPTION
## Summary
- show the reduced AI video offer price on all language variants with a struck $700 and red $500* callout
- add reusable `.price-old` and `.price-new` utility styles for the updated pricing display

## Testing
- not run (static content changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915fd565378832db00a8082315e1628)